### PR TITLE
17 setup vm web server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,11 +130,15 @@ celerybeat.pid
 # Environments
 .env
 .venv
+env.*
 env/
 venv/
 ENV/
 env.bak/
 venv.bak/
+.vagrant
+!env.*.example
+
 
 # Spyder project settings
 .spyderproject

--- a/vagrant/Vagrantfile.web
+++ b/vagrant/Vagrantfile.web
@@ -23,13 +23,15 @@ Vagrant.configure("2") do |config|
                         libnss3-dev libssl-dev libreadline-dev libffi-dev wget \
                         libsqlite3-dev
 
-    cd /usr/src
-    sudo wget https://www.python.org/ftp/python/2.6.9/Python-2.6.9.tgz
-    sudo tar xzf Python-2.6.9.tgz
-    cd Python-2.6.9
-    sudo ./configure --prefix=/opt/python2.6
-    sudo make
-    sudo make install
+    if ! /opt/python2.6/bin/python2.6 --version > /dev/null 2>&1; then
+      cd /usr/src
+      sudo wget https://www.python.org/ftp/python/2.6.9/Python-2.6.9.tgz
+      sudo tar xzf Python-2.6.9.tgz
+      cd Python-2.6.9
+      sudo ./configure --prefix=/opt/python2.6
+      sudo make
+      sudo make install
+    fi
 
     /opt/python2.6/bin/python2.6 --version
     sudo ln -s /opt/python2.6/bin/python2.6 /usr/local/bin/python2

--- a/vagrant/Vagrantfile.web
+++ b/vagrant/Vagrantfile.web
@@ -32,6 +32,6 @@ Vagrant.configure("2") do |config|
     sudo make install
 
     /opt/python2.6/bin/python2.6 --version
-    sudo ln -s /opt/python2.6/bin/python2.6 /usr/local/bin/python
+    sudo ln -s /opt/python2.6/bin/python2.6 /usr/local/bin/python2
   SHELL
 end

--- a/vagrant/Vagrantfile.web
+++ b/vagrant/Vagrantfile.web
@@ -1,7 +1,7 @@
 load File.expand_path("../env.rb", __FILE__)
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/jammy64"
+  config.vm.box = ENV_WEB["OS"]
   config.vm.network "public_network",
     ip: ENV_WEB["IP"],
     netmask: ENV_WEB["NETMASK"]

--- a/vagrant/Vagrantfile.web
+++ b/vagrant/Vagrantfile.web
@@ -1,0 +1,37 @@
+load File.expand_path("../env.rb", __FILE__)
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/jammy64"
+  config.vm.network "public_network",
+    ip: ENV_WEB["IP"],
+    netmask: ENV_WEB["NETMASK"],
+
+  config.vm.provider ENV_WEB["PROVIDER"] do |vb|
+    vb.name = ENV_WEB["VM_NAME"]
+    vb.memory = ENV_WEB["VM_MEMORY"]
+    vb.cpus = ENV_WEB["VM_CPUS"]
+  end
+
+  config.vm.provision "shell", inline: <<-SHELL
+    sudo apt update
+    sudo apt install -y nginx openssh-server
+
+    sudo systemctl enable ssh
+    sudo systemctl start ssh
+
+    sudo apt install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev \
+                        libnss3-dev libssl-dev libreadline-dev libffi-dev wget \
+                        libsqlite3-dev
+
+    cd /usr/src
+    sudo wget https://www.python.org/ftp/python/2.6.9/Python-2.6.9.tgz
+    sudo tar xzf Python-2.6.9.tgz
+    cd Python-2.6.9
+    sudo ./configure --prefix=/opt/python2.6
+    sudo make
+    sudo make install
+
+    /opt/python2.6/bin/python2.6 --version
+    sudo ln -s /opt/python2.6/bin/python2.6 /usr/local/bin/python
+  SHELL
+end

--- a/vagrant/Vagrantfile.web
+++ b/vagrant/Vagrantfile.web
@@ -13,6 +13,7 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.provision "shell", inline: <<-SHELL
+    set -e
     sudo apt update
     sudo apt install -y nginx openssh-server
 

--- a/vagrant/Vagrantfile.web
+++ b/vagrant/Vagrantfile.web
@@ -4,7 +4,7 @@ Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/jammy64"
   config.vm.network "public_network",
     ip: ENV_WEB["IP"],
-    netmask: ENV_WEB["NETMASK"],
+    netmask: ENV_WEB["NETMASK"]
 
   config.vm.provider ENV_WEB["PROVIDER"] do |vb|
     vb.name = ENV_WEB["VM_NAME"]

--- a/vagrant/Vagrantfile.web
+++ b/vagrant/Vagrantfile.web
@@ -31,6 +31,8 @@ Vagrant.configure("2") do |config|
       sudo ./configure --prefix=/opt/python2.6
       sudo make
       sudo make install
+      cd ..
+      sudo rm -rf Python-2.6.9 Python-2.6.9.tgz
     fi
 
     /opt/python2.6/bin/python2.6 --version

--- a/vagrant/env.rb.example
+++ b/vagrant/env.rb.example
@@ -1,0 +1,8 @@
+ENV_WEB = {
+  "IP"          => "192.168.56.10", 
+  "NETMASK"     => "255.255.255.0",
+  "PROVIDER"    => "virtualbox",
+  "VM_NAME"     => "vm-web-server",
+  "VM_MEMORY"   => 1024,
+  "VM_CPUS"     => 1
+}

--- a/vagrant/env.rb.example
+++ b/vagrant/env.rb.example
@@ -1,6 +1,7 @@
 ENV_WEB = {
   "IP"          => "192.168.56.10", 
   "NETMASK"     => "255.255.255.0",
+  "OS"          => "ubuntu/jammy64",  # or "net9/ubuntu-24.04-arm64" for MacOS
   "PROVIDER"    => "virtualbox",
   "VM_NAME"     => "vm-web-server",
   "VM_MEMORY"   => 1024,


### PR DESCRIPTION
**Add Vagrant setup for web server with Python 2.6 installation**

Description:

- Added env.rb.example file to define VM configuration variables.

- Created Vagrantfile to set up a web server using VirtualBox.

- Configures Ubuntu-based VM with Nginx, OpenSSH, and Python 2.6 built from source.

- Symlinks Python 2.6 binary as python2 for compatibility.