### PR TITLE
fix: add explicit dependence on object in CustomTimedRotatingHandler

### DIFF
--- a/agents/utils/logtools.py
+++ b/agents/utils/logtools.py
@@ -39,7 +39,7 @@ def maybe_make_dir(path):
                 raise
 
 
-class CustomTimedRotatingHandler(TimedRotatingFileHandler):
+class CustomTimedRotatingHandler(TimedRotatingFileHandler, object):
 
     def __init__(
         self,


### PR DESCRIPTION
This PR fixes the bug where `CustomTimedRotatingHandler` doesn't inherit Python `object`, which is required on Python 2.6 (but no required on Python 2.7+).