### PR TITLE
5 extend agent script with http post functionality python 26

### DIFF
--- a/agents/agent.py
+++ b/agents/agent.py
@@ -231,7 +231,7 @@ class ServerAgent(object):
         """
         return self._is_port_open() and self._is_process_running()
 
-    def to_dict(self):
+    def status_to_dict(self):
         return {
             'os': self.os_type,
             'hostname': self.hostname,
@@ -242,7 +242,7 @@ class ServerAgent(object):
             'healthy': self.service_healthy(),
         }
 
-    def to_json(self):
+    def status_to_json(self):
         """Dump host metadata to json file."""
         try:
             msg = json.dumps(self.to_dict())
@@ -254,7 +254,7 @@ class ServerAgent(object):
                 fallback_logger=self.fallback_logger,
             )
 
-    def to_txt(self):
+    def status_to_txt(self):
         """Dump host metadata to txt file as key-value pairs."""
         data = self.to_dict()
 
@@ -268,7 +268,7 @@ class ServerAgent(object):
                 fallback_logger=self.fallback_logger,
             )
 
-    def to_controller(self, timeout=5):
+    def status_to_controller(self, timeout=5):
         """
         Send system's metadata to controller.
 

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -32,7 +32,11 @@ def get_ip_from_interface(interface):
     Returns:
         str: On success, IP address is returned.
     """
-    addresses = psutil.net_if_addrs()[interface]
+    net_if_dict = psutil.net_if_addrs()
+    if interface not in net_if_dict:
+        return
+
+    addresses = net_if_dict[interface]
 
     for address in addresses:
         if address.address.startswith('127.'):

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -62,16 +62,13 @@ class ServerAgent(object):
         processes=None,
         interface=None,
         controller_url=None,
-        config_file=None,
     ):
         self.server_name = server_name
-        self.port = port or self.port
-        self.processes = processes or self.processes
+        self.port = port if port is not None else self.port
+        self.processes = processes if processes is not None else self.processes
         self.interface = interface
 
         self.controller_url = controller_url
-
-        self.config_file = config_file
 
     @classmethod
     def from_config_file(cls, filename=None, log_path=None):
@@ -86,10 +83,10 @@ class ServerAgent(object):
         Returns:
             ServerAgent: Child instance of ServerAgent.
         """
-        agent = cls(config_file=filename)
+        agent = cls()
 
         agent.setup_logging(path=log_path)
-        agent._parse_config_file()
+        agent._parse_config_file(filename)
 
         agent.collect_server_metadata()
 
@@ -114,7 +111,7 @@ class ServerAgent(object):
         if not isinstance(value, Sequence):
             raise TypeError(
                 (
-                    'Process names must be provided as a sequence '
+                    'Process names must be provided as a string or a sequence '
                     '(list, tuple etc.), not %s' % type(value)
                 )
             )
@@ -139,63 +136,68 @@ class ServerAgent(object):
             '_'.join([self.server_name, 'fallback'])
         )
 
-    def _parse_config_file(self):
+    def _parse_config_file(self, filename=None):
         """Parse server's config file using ConfigParser."""
+        filename = (
+            filename
+            or pkg_resources.resource_filename(
+                self.__class__.__module__, 'config.ini'
+            )
+        )
+
         config = ConfigParser.ConfigParser()
+        config.read(filename)
 
-        if self.config_file:
-            config.read(self.config_file)
+        if config.sections():
+            self.server_name = get_config_option(
+                config,
+                'server',
+                'name',
+                default=self.server_name,
+                logger=self.logger,
+                fallback_logger=self.fallback_logger,
+            )
 
-            if config.sections():
-                self.server_name = get_config_option(
-                    config,
-                    'server',
-                    'name',
-                    default=self.server_name,
-                    logger=self.logger,
-                    fallback_logger=self.fallback_logger,
-                )
+            self.port = get_config_option(
+                config,
+                'server',
+                'port',
+                default=self.port,
+                logger=self.logger,
+                fallback_logger=self.fallback_logger,
+                cast=int,
+            )
 
-                self.port = get_config_option(
-                    config,
-                    'server',
-                    'port',
-                    default=self.port,
-                    logger=self.logger,
-                    fallback_logger=self.fallback_logger,
-                    cast=int,
-                )
+            self.processes = get_config_option(
+                config,
+                'server',
+                'processes',
+                default=self.processes,
+                logger=self.logger,
+                fallback_logger=self.fallback_logger,
+                cast=(
+                    lambda procs: [
+                        proc.strip() for proc in procs.split(',')
+                    ]
+                ),
+            )
 
-                self.processes = get_config_option(
-                    config,
-                    'server',
-                    'processes',
-                    default=self.processes,
-                    logger=self.logger,
-                    fallback_logger=self.fallback_logger,
-                    cast=(
-                        lambda procs: [
-                            proc.strip() for proc in procs.split(',')
-                        ]
-                    ),
-                )
+            self.interface = get_config_option(
+                config,
+                'server',
+                'interface',
+                logger=self.logger,
+                fallback_logger=self.fallback_logger,
+            )
 
-                self.interface = get_config_option(
-                    config,
-                    'server',
-                    'interface',
-                    logger=self.logger,
-                    fallback_logger=self.fallback_logger,
-                )
-
-                self.controller_url = get_config_option(
-                    config,
-                    'controller',
-                    'url',
-                    self.controller_url,
-                    logger=self.logger,
-                    fallback_logger=self.fallback_logger,
-                )
+            self.controller_url = get_config_option(
+                config,
+                'controller',
+                'url',
+                self.controller_url,
+                logger=self.logger,
+                fallback_logger=self.fallback_logger,
+            )
 
     def collect_server_metadata(self):
         """

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -6,6 +6,7 @@ import logging.config
 import platform
 import socket
 import subprocess
+from collections import Sequence
 
 import ConfigParser
 import pkg_resources
@@ -54,13 +55,6 @@ class ServerAgent(object):
     """
     __metaclass__ = abc.ABCMeta
 
-    server_name = None
-    port = -1
-    processes = []
-    controller_url = None
-    config_file = None
-    log_path = None
-
     def __init__(
         self,
         server_name=None,
@@ -68,40 +62,80 @@ class ServerAgent(object):
         processes=None,
         controller_url=None,
         config_file=None,
-        log_path=None,
     ):
-        if server_name:
-            self.server_name = server_name
-        if port:
-            self.port = port
-        if processes:
-            self.processes = processes
+        self.server_name = server_name
+        self.port = port or self.port
+        self.processes = processes or self.processes
 
-        if controller_url:
-            self.controller_url = controller_url
+        self.controller_url = controller_url
 
-        if config_file:
-            self.config_file = config_file
+        self.config_file = config_file
 
-        # Setup logging
-        if log_path:
-            self.log_path = log_path
+    @classmethod
+    def from_config_file(cls, filename=None, log_path=None):
+        """
+        Create an agent from a configuration (.ini) file.
+
+        Parameters:
+            filename (str): Path to configuration file. Default is None.
+            log_path (str): Path to where the log files will be stored.
+                Default is None.
+
+        Returns:
+            ServerAgent: Child instance of ServerAgent.
+        """
+        agent = cls(config_file=filename)
+
+        agent.setup_logging(path=log_path)
+        agent._parse_config_file()
+
+        agent.collect_server_metadata()
+
+        return agent
+
+    @property
+    def port(self):
+        return getattr(self, '_port', -1)
+
+    @port.setter
+    def port(self, value):
+        if not isinstance(value, int):
+            raise TypeError('Port number must be an integer')
+        self._port = value
+
+    @property
+    def processes(self):
+        return getattr(self, '_processes', [])
+
+    @processes.setter
+    def processes(self, value):
+        if not isinstance(value, Sequence):
+            raise TypeError(
+                (
+                    'Process names must be provided as a sequence '
+                    '(list, tuple etc.), not %s' % type(value)
+                )
+            )
+        self._processes = value
+
+    def setup_logging(self, path=None):
+        # Have each child dump logs inside their own subpackage by default
+        path = (
+            path
+            or pkg_resources.resource_filename(
+                self.__class__.__module__, 'agent.log'
+            )
+        )
 
         logging.config.fileConfig(
             log_config_path,
-            defaults={
-                'agent_name': self.server_name, 'log_path': self.log_path
-            },
+            defaults={'agent_name': self.server_name, 'log_path': path},
         )
 
         self.logger = logging.getLogger(self.server_name)
         self.fallback_logger = logging.getLogger(
             '_'.join([self.server_name, 'fallback'])
         )
-
-        self._parse_config_file()
-
-        self._set_server_metadata()
 
     def _parse_config_file(self):
         """Parse server's config file using ConfigParser."""
@@ -161,7 +195,7 @@ class ServerAgent(object):
                     fallback_logger=self.fallback_logger,
                 )
 
-    def _set_server_metadata(self):
+    def collect_server_metadata(self):
         """
         Attempt setting server metadata such as the hostname, IP address,
         uptime, and timestamp.

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -55,16 +55,21 @@ class ServerAgent(object):
     __metaclass__ = abc.ABCMeta
 
     config_file = None
-    log_dir = None
+    log_path = None
     server_name = None
     port = -1
     controller_url = None
 
-    def __init__(self):
+    def __init__(self, log_path=None):
         # Setup logging
+        if log_path:
+            self.log_path = log_path
+
         logging.config.fileConfig(
             log_config_path,
-            defaults={'agent_name': self.server_name, 'log_dir': self.log_dir},
+            defaults={
+                'agent_name': self.server_name, 'log_path': self.log_path
+            },
         )
 
         self.logger = logging.getLogger(self.server_name)

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -56,7 +56,6 @@ class ServerAgent(object):
     config_file = None
     log_dir = None
     server_name = None
-    processes = []
     port = -1
 
     def __init__(self):
@@ -70,6 +69,8 @@ class ServerAgent(object):
         self.fallback_logger = logging.getLogger(
             '_'.join([self.server_name, 'fallback'])
         )
+
+        self.processes = []
 
         self._parse_config_file()
 

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -350,7 +350,7 @@ class ServerAgent(object):
             str: JSON status string.
         """
         try:
-            status = json.dumps(self.status_to_dict())
+            status = json.dumps(self.status_to_dict(), default=str)
 
             if log:
                 try:

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -242,14 +242,37 @@ class ServerAgent(object):
             'healthy': self.service_healthy(),
         }
 
-    def status_to_json(self):
-        """Dump host metadata to json file."""
+    def status_to_json(self, log=False):
+        """
+        Dump host metadata to json file.
+
+        Parameters:
+            log (bool): Whether to log JSON status string to the logfile.
+                Default is False.
+
+        Returns:
+            str: JSON status string.
+        """
         try:
-            msg = json.dumps(self.to_dict())
-            self.logger.info(msg)
-        except (IOError, OSError) as e:
+            status = json.dumps(self.to_dict())
+
+            if log:
+                try:
+                    self.logger.info(status)
+                except (IOError, OSError) as e:
+                    maybe_log_message(
+                        'Error logging to file: %s' % str(e),
+                        self.logger,
+                        fallback_logger=self.fallback_logger,
+                    )
+                finally:
+                    return status
+        except TypeError as e:
             maybe_log_message(
-                'Error logging to file: %s' % str(e),
+                (
+                    'JSON serialization of status failed '
+                    'due to error: %s' % str(e)
+                ),
                 self.logger,
                 fallback_logger=self.fallback_logger,
             )
@@ -285,7 +308,7 @@ class ServerAgent(object):
 
             return
 
-        payload = json.dumps(self.status_to_dict())
+        payload = self.status_to_json(log=False)
 
         headers = {'Content-Type': 'application/json'}
         if api_key:

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -10,6 +10,7 @@ import subprocess
 import ConfigParser
 import pkg_resources
 import psutil
+import urllib2
 
 from .utils.helpers import get_config_option
 from .utils.logtools import maybe_log_message
@@ -261,3 +262,43 @@ class ServerAgent(object):
                 self.logger,
                 fallback_logger=self.fallback_logger,
             )
+
+    def to_controller(self, timeout=5):
+        if not self.controller_url:
+            maybe_log_message(
+                "Couldn't send status update: controller URL is not set",
+                logger=self.logger,
+                fallback_logger=self.fallback_logger,
+            )
+
+            return
+
+        payload = json.dumps(self.to_dict())
+        headers = {'Content-Type': 'application/json'}
+
+        request = urllib2.Request(
+            self.controller_url, payload, headers=headers
+        )
+
+        status_code = None
+
+        try:
+            response = urllib2.urlopen(request, timeout=timeout)
+            status_code = response.getcode()
+        except (urllib2.URLError, urllib2.HTTPError) as e:
+            status_code = getattr(e, 'code', None)
+
+            maybe_log_message(
+                'POST request to controller failed due to error: %s' % str(e),
+                logger=self.logger,
+                fallback_logger=self.fallback_logger,
+                exc_info=True,
+            )
+        finally:
+            if status_code:
+                maybe_log_message(
+                    'POST request status: %s' % str(status_code),
+                    logger=self.logger,
+                    fallback_logger=self.fallback_logger,
+                    level=logging.INFO,
+                )

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -74,6 +74,11 @@ class ServerAgent(object):
 
         self.controller_url = controller_url
 
+        # Init server metadata to prevent AttributeError and to indicate
+        # to user that collect_server_metadata hasn't been called.
+        self.os_type = self.hostname = self.ip = None
+        self.uptime = self.timestamp = None
+
     @classmethod
     def from_config_file(cls, filename=None, log_path=None):
         """

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -57,6 +57,7 @@ class ServerAgent(object):
     log_dir = None
     server_name = None
     port = -1
+    controller_url = None
 
     def __init__(self):
         # Setup logging
@@ -88,6 +89,14 @@ class ServerAgent(object):
                     config,
                     'server',
                     'interface',
+                    logger=self.logger,
+                    fallback_logger=self.fallback_logger,
+                )
+
+                self.controller_url = get_config_option(
+                    config,
+                    'controller',
+                    'url',
                     logger=self.logger,
                     fallback_logger=self.fallback_logger,
                 )

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -419,7 +419,7 @@ class ServerAgent(object):
         try:
             response = urllib2.urlopen(request, timeout=timeout)
             status_code = response.getcode()
-        except (urllib2.URLError, urllib2.HTTPError) as e:
+        except (urllib2.URLError, urllib2.HTTPError, socket.timeout) as e:
             status_code = getattr(e, 'code', None)
 
             maybe_log_message(

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -129,7 +129,7 @@ class ServerAgent(object):
         path = (
             path
             or pkg_resources.resource_filename(
-                self.__class__.__module__, 'agent.log'
+                self.__class__.__module__, 'logs/agent.log'
             )
         )
 

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -269,6 +269,12 @@ class ServerAgent(object):
             )
 
     def to_controller(self, timeout=5):
+        """
+        Send system's metadata to controller.
+
+        Parameters:
+            timeout (int): POST request timeout in seconds. Default is 5.
+        """
         if not self.controller_url:
             maybe_log_message(
                 "Couldn't send status update: controller URL is not set",

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -268,12 +268,13 @@ class ServerAgent(object):
                 fallback_logger=self.fallback_logger,
             )
 
-    def status_to_controller(self, timeout=5):
+    def status_to_controller(self, timeout=5, api_key=None):
         """
         Send system's metadata to controller.
 
         Parameters:
             timeout (int): POST request timeout in seconds. Default is 5.
+            api_key (str): Authentication API key. Default is None.
         """
         if not self.controller_url:
             maybe_log_message(
@@ -285,7 +286,10 @@ class ServerAgent(object):
             return
 
         payload = json.dumps(self.status_to_dict())
+
         headers = {'Content-Type': 'application/json'}
+        if api_key:
+            headers.update({'X-API-Key': api_key})
 
         request = urllib2.Request(
             self.controller_url, payload, headers=headers

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -361,8 +361,8 @@ class ServerAgent(object):
                         self.logger,
                         fallback_logger=self.fallback_logger,
                     )
-                finally:
-                    return status
+
+            return status
         except TypeError as e:
             maybe_log_message(
                 (

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -97,8 +97,6 @@ class ServerAgent(object):
         agent.setup_logging(path=log_path)
         agent._parse_config_file(filename)
 
-        agent.collect_server_metadata()
-
         return agent
 
     @property

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -54,13 +54,35 @@ class ServerAgent(object):
     """
     __metaclass__ = abc.ABCMeta
 
-    config_file = None
-    log_path = None
     server_name = None
     port = -1
+    processes = []
     controller_url = None
+    config_file = None
+    log_path = None
 
-    def __init__(self, log_path=None):
+    def __init__(
+        self,
+        server_name=None,
+        port=None,
+        processes=None,
+        controller_url=None,
+        config_file=None,
+        log_path=None,
+    ):
+        if server_name:
+            self.server_name = server_name
+        if port:
+            self.port = port
+        if processes:
+            self.processes = processes
+
+        if controller_url:
+            self.controller_url = controller_url
+
+        if config_file:
+            self.config_file = config_file
+
         # Setup logging
         if log_path:
             self.log_path = log_path
@@ -77,8 +99,6 @@ class ServerAgent(object):
             '_'.join([self.server_name, 'fallback'])
         )
 
-        self.processes = []
-
         self._parse_config_file()
 
         self._set_server_metadata()
@@ -91,6 +111,39 @@ class ServerAgent(object):
             config.read(self.config_file)
 
             if config.sections():
+                self.server_name = get_config_option(
+                    config,
+                    'server',
+                    'name',
+                    default=self.server_name,
+                    logger=self.logger,
+                    fallback_logger=self.fallback_logger,
+                )
+
+                self.port = get_config_option(
+                    config,
+                    'server',
+                    'port',
+                    default=self.port,
+                    logger=self.logger,
+                    fallback_logger=self.fallback_logger,
+                    cast=int,
+                )
+
+                self.processes = get_config_option(
+                    config,
+                    'server',
+                    'processes',
+                    default=self.processes,
+                    logger=self.logger,
+                    fallback_logger=self.fallback_logger,
+                    cast=(
+                        lambda procs: [
+                            proc.strip() for proc in procs.split(',')
+                        ]
+                    ),
+                )
+
                 self.interface = get_config_option(
                     config,
                     'server',
@@ -103,6 +156,7 @@ class ServerAgent(object):
                     config,
                     'controller',
                     'url',
+                    self.controller_url,
                     logger=self.logger,
                     fallback_logger=self.fallback_logger,
                 )
@@ -279,7 +333,7 @@ class ServerAgent(object):
 
     def status_to_txt(self):
         """Dump host metadata to txt file as key-value pairs."""
-        data = self.to_dict()
+        data = self.status_to_dict()
 
         try:
             for k, v in data.items():

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -60,12 +60,14 @@ class ServerAgent(object):
         server_name=None,
         port=None,
         processes=None,
+        interface=None,
         controller_url=None,
         config_file=None,
     ):
         self.server_name = server_name
         self.port = port or self.port
         self.processes = processes or self.processes
+        self.interface = interface
 
         self.controller_url = controller_url
 

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -254,7 +254,7 @@ class ServerAgent(object):
             str: JSON status string.
         """
         try:
-            status = json.dumps(self.to_dict())
+            status = json.dumps(self.status_to_dict())
 
             if log:
                 try:

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -284,7 +284,7 @@ class ServerAgent(object):
 
             return
 
-        payload = json.dumps(self.to_dict())
+        payload = json.dumps(self.status_to_dict())
         headers = {'Content-Type': 'application/json'}
 
         request = urllib2.Request(

--- a/agents/dns/config.ini
+++ b/agents/dns/config.ini
@@ -1,2 +1,8 @@
 [server]
+name=
+port=53
+processes=
 interface=
+
+[controller]
+url=

--- a/agents/dns/dns.py
+++ b/agents/dns/dns.py
@@ -4,26 +4,22 @@ from ..agent import ServerAgent
 
 
 class DNSAgent(ServerAgent):
-    server_name = 'dns'
-    port = 53
-    processes = ['named', 'bind9']
-    config_file = pkg_resources.resource_filename(__name__, 'config.ini')
-    log_path = pkg_resources.resource_filename(__name__, 'logs/agent.log')
 
     def __init__(
         self,
-        server_name=None,
-        port=None,
+        server_name='dns',
+        port=53,
         processes=None,
         controller_url=None,
         config_file=None,
-        log_path=None,
     ):
         super(DNSAgent, self).__init__(
             server_name=server_name,
             port=port,
-            processes=processes,
+            processes=processes or ['named', 'bind9'],
             controller_url=controller_url,
-            config_file=config_file,
-            log_path=log_path,
+            config_file=(
+                config_file
+                or pkg_resources.resource_filename(__name__, 'config.ini')
+            ),
         )

--- a/agents/dns/dns.py
+++ b/agents/dns/dns.py
@@ -4,12 +4,26 @@ from ..agent import ServerAgent
 
 
 class DNSAgent(ServerAgent):
-    config_file = pkg_resources.resource_filename(__name__, 'config.ini')
-    log_dir = pkg_resources.resource_filename(__name__, 'logs')
     server_name = 'dns'
+    port = 53
+    processes = ['named', 'bind9']
+    config_file = pkg_resources.resource_filename(__name__, 'config.ini')
+    log_path = pkg_resources.resource_filename(__name__, 'logs/agent.log')
 
-    def __init__(self, dns_processes=None):
-        super(DNSAgent, self).__init__()
-
-        self.port = 53
-        self.processes = dns_processes or ['named', 'bind9']
+    def __init__(
+        self,
+        server_name=None,
+        port=None,
+        processes=None,
+        controller_url=None,
+        config_file=None,
+        log_path=None,
+    ):
+        super(DNSAgent, self).__init__(
+            server_name=server_name,
+            port=port,
+            processes=processes,
+            controller_url=controller_url,
+            config_file=config_file,
+            log_path=log_path,
+        )

--- a/agents/dns/dns.py
+++ b/agents/dns/dns.py
@@ -10,6 +10,7 @@ class DNSAgent(ServerAgent):
         server_name='dns',
         port=53,
         processes=None,
+        interface=None,
         controller_url=None,
         config_file=None,
     ):
@@ -17,6 +18,7 @@ class DNSAgent(ServerAgent):
             server_name=server_name,
             port=port,
             processes=processes or ['named', 'bind9'],
+            interface=interface,
             controller_url=controller_url,
             config_file=(
                 config_file

--- a/agents/dns/dns.py
+++ b/agents/dns/dns.py
@@ -12,7 +12,6 @@ class DNSAgent(ServerAgent):
         processes=None,
         interface=None,
         controller_url=None,
-        config_file=None,
     ):
         super(DNSAgent, self).__init__(
             server_name=server_name,
@@ -20,8 +19,4 @@ class DNSAgent(ServerAgent):
             processes=processes or ['named', 'bind9'],
             interface=interface,
             controller_url=controller_url,
-            config_file=(
-                config_file
-                or pkg_resources.resource_filename(__name__, 'config.ini')
-            ),
         )

--- a/agents/requirements.txt
+++ b/agents/requirements.txt
@@ -1,4 +1,4 @@
 setuptools==33.1.1
-psutil==6.1.1
+psutil==5.7.0
 pytest==3.2.5
 mock==2.0.0

--- a/agents/requirements.txt
+++ b/agents/requirements.txt
@@ -1,3 +1,4 @@
 setuptools==33.1.1
 psutil==6.1.1
 pytest==3.2.5
+mock==2.0.0

--- a/agents/requirements.txt
+++ b/agents/requirements.txt
@@ -1,1 +1,3 @@
 setuptools==33.1.1
+psutil==6.1.1
+pytest==3.2.5

--- a/agents/smtp/config.ini
+++ b/agents/smtp/config.ini
@@ -1,4 +1,7 @@
 [server]
+name=
+port=25
+processes=
 interface=
 
 [controller]

--- a/agents/smtp/config.ini
+++ b/agents/smtp/config.ini
@@ -1,2 +1,5 @@
 [server]
 interface=
+
+[controller]
+url=

--- a/agents/smtp/smtp.py
+++ b/agents/smtp/smtp.py
@@ -5,11 +5,11 @@ from ..agent import ServerAgent
 
 class SMTPAgent(ServerAgent):
     config_file = pkg_resources.resource_filename(__name__, 'config.ini')
-    log_dir = pkg_resources.resource_filename(__name__, 'logs')
+    log_path = pkg_resources.resource_filename(__name__, 'logs/agent.log')
     server_name = 'smtp'
 
-    def __init__(self, smtp_processes=None):
-        super(SMTPAgent, self).__init__()
+    def __init__(self, log_path=None, smtp_processes=None):
+        super(SMTPAgent, self).__init__(log_path=log_path)
 
         self.port = 25
         self.processes = smtp_processes or [

--- a/agents/smtp/smtp.py
+++ b/agents/smtp/smtp.py
@@ -4,14 +4,26 @@ from ..agent import ServerAgent
 
 
 class SMTPAgent(ServerAgent):
+    server_name = 'smtp'
+    port = 25
+    processes = ['postfix', 'exim', 'sendmail', 'master']
     config_file = pkg_resources.resource_filename(__name__, 'config.ini')
     log_path = pkg_resources.resource_filename(__name__, 'logs/agent.log')
-    server_name = 'smtp'
 
-    def __init__(self, log_path=None, smtp_processes=None):
-        super(SMTPAgent, self).__init__(log_path=log_path)
-
-        self.port = 25
-        self.processes = smtp_processes or [
-            'postfix', 'exim', 'sendmail', 'master'
-        ]
+    def __init__(
+        self,
+        server_name=None,
+        port=None,
+        processes=None,
+        controller_url=None,
+        config_file=None,
+        log_path=None,
+    ):
+        super(SMTPAgent, self).__init__(
+            server_name=server_name,
+            port=port,
+            processes=processes,
+            controller_url=controller_url,
+            config_file=config_file,
+            log_path=log_path,
+        )

--- a/agents/smtp/smtp.py
+++ b/agents/smtp/smtp.py
@@ -12,7 +12,6 @@ class SMTPAgent(ServerAgent):
         processes=None,
         interface=None,
         controller_url=None,
-        config_file=None,
     ):
         super(SMTPAgent, self).__init__(
             server_name=server_name,
@@ -20,8 +19,4 @@ class SMTPAgent(ServerAgent):
             processes=processes or ['postfix', 'exim', 'sendmail', 'master'],
             interface=interface,
             controller_url=controller_url,
-            config_file=(
-                config_file
-                or pkg_resources.resource_filename(__name__, 'config.ini')
-            ),
         )

--- a/agents/smtp/smtp.py
+++ b/agents/smtp/smtp.py
@@ -4,26 +4,22 @@ from ..agent import ServerAgent
 
 
 class SMTPAgent(ServerAgent):
-    server_name = 'smtp'
-    port = 25
-    processes = ['postfix', 'exim', 'sendmail', 'master']
-    config_file = pkg_resources.resource_filename(__name__, 'config.ini')
-    log_path = pkg_resources.resource_filename(__name__, 'logs/agent.log')
 
     def __init__(
         self,
-        server_name=None,
-        port=None,
+        server_name='smtp',
+        port=25,
         processes=None,
         controller_url=None,
         config_file=None,
-        log_path=None,
     ):
         super(SMTPAgent, self).__init__(
             server_name=server_name,
             port=port,
-            processes=processes,
+            processes=processes or ['postfix', 'exim', 'sendmail', 'master'],
             controller_url=controller_url,
-            config_file=config_file,
-            log_path=log_path,
+            config_file=(
+                config_file
+                or pkg_resources.resource_filename(__name__, 'config.ini')
+            ),
         )

--- a/agents/smtp/smtp.py
+++ b/agents/smtp/smtp.py
@@ -10,6 +10,7 @@ class SMTPAgent(ServerAgent):
         server_name='smtp',
         port=25,
         processes=None,
+        interface=None,
         controller_url=None,
         config_file=None,
     ):
@@ -17,6 +18,7 @@ class SMTPAgent(ServerAgent):
             server_name=server_name,
             port=port,
             processes=processes or ['postfix', 'exim', 'sendmail', 'master'],
+            interface=interface,
             controller_url=controller_url,
             config_file=(
                 config_file

--- a/agents/tests/test_agent.py
+++ b/agents/tests/test_agent.py
@@ -5,7 +5,7 @@ import mock
 from agents.smtp import smtp
 
 
-def test_to_controller_success():
+def test_status_to_controller_success():
     def mock_urlopen(request, timeout=5):
         class MockResponse(object):
             def getcode(self):

--- a/agents/tests/test_agent.py
+++ b/agents/tests/test_agent.py
@@ -74,6 +74,29 @@ def test_status_to_controller_success():
         )
 
 
+def test_status_to_controller_missing_url():
+    """Test that missing controller URL is properly handled and logged."""
+    with tempfile.NamedTemporaryFile() as tmp:
+        agent = MockAgent(port=12345)
+        agent.setup_logging(tmp.name)
+        agent.collect_server_metadata()
+
+        # Set controller's URL explicitly to be independent of changes
+        # of default values in agent.py/
+        agent.controller_url = None
+
+        agent.status_to_controller()
+
+        tmp.seek(0)
+        contents = tmp.read()
+
+        msg = "Couldn't send status update: controller URL is not set"
+
+        assert msg in contents, (
+            'Expected %s in logs, got:\n%s' % (msg, contents)
+        )
+
+
 def test_status_to_controller_error():
     """
     Test that the HTTP and URL failures of POST request to controller are

--- a/agents/tests/test_agent.py
+++ b/agents/tests/test_agent.py
@@ -61,6 +61,10 @@ def test_type_checks_on_config_parse():
 
 
 def test_status_to_json_type_error():
+    """
+    Test that the TypeError is handled and logged on JSON serialization
+    failure.
+    """
     class MockUnserializableParameter:
         def __str__(self):
             raise TypeError("Can't serialize me")

--- a/agents/tests/test_agent.py
+++ b/agents/tests/test_agent.py
@@ -2,6 +2,7 @@ import tempfile
 
 import mock
 import pytest
+import urllib2
 
 from agents.agent import ServerAgent
 
@@ -22,6 +23,7 @@ class MockAgent(ServerAgent):
 
 
 def test_type_checks_on_init():
+    """Test that type checks fail initialization with bad parameters."""
     with pytest.raises(TypeError):
         MockAgent(port='invalid')
 
@@ -30,6 +32,10 @@ def test_type_checks_on_init():
 
 
 def test_type_checks_on_config_parse():
+    """
+    Test that type checks fail initialization with bad config file
+    parameters.
+    """
     with tempfile.NamedTemporaryFile() as tmp:
         tmp.write('[server]\nname=mock\nport=invalid\nprocesses=proc1')
         tmp.flush()
@@ -39,6 +45,10 @@ def test_type_checks_on_config_parse():
 
 
 def test_status_to_controller_success():
+    """
+    Test that successful POST request to controller is properly handled
+    and logged.
+    """
     def mock_urlopen(request, timeout=5):
         class MockResponse(object):
             def getcode(self):
@@ -60,4 +70,41 @@ def test_status_to_controller_success():
 
         assert 'POST request status: 201' in contents, (
             'Expected "POST request status: 201" in logs, got:\n%s' % contents
+        )
+
+
+def test_status_to_controller_http_error():
+    """
+    Test that the HTTP failure of POST request to controller is properly
+    handled and logged.
+    """
+    def mock_urlopen(request, timeout=5):
+        raise urllib2.HTTPError(
+            url='http://mock/api/status/',
+            code=500,
+            msg='Internal Server Error',
+            hdrs=None,
+            fp=None,
+        )
+
+    with tempfile.NamedTemporaryFile() as tmp:
+        agent = MockAgent(port=12345)
+        agent.setup_logging(tmp.name)
+        agent.collect_server_metadata()
+
+        agent.controller_url = 'http://mock/api/status/'
+
+        with mock.patch('urllib2.urlopen', mock_urlopen):
+            agent.status_to_controller()
+
+        tmp.seek(0)
+        contents = tmp.read()
+
+        msg = (
+            'POST request to controller failed due to error: '
+            'HTTP Error 500: Internal Server Error'
+        )
+
+        assert msg in contents, (
+            'Expected %s in logs, got:\n%s' % (msg, contents)
         )

--- a/agents/tests/test_agent.py
+++ b/agents/tests/test_agent.py
@@ -73,38 +73,51 @@ def test_status_to_controller_success():
         )
 
 
-def test_status_to_controller_http_error():
+def test_status_to_controller_error():
     """
     Test that the HTTP failure of POST request to controller is properly
     handled and logged.
     """
-    def mock_urlopen(request, timeout=5):
-        raise urllib2.HTTPError(
-            url='http://mock/api/status/',
-            code=500,
-            msg='Internal Server Error',
-            hdrs=None,
-            fp=None,
-        )
+    output = [
+        (
+            urllib2.HTTPError(
+                url='http://mock/api/status/',
+                code=500,
+                msg='Internal Server Error',
+                hdrs=None,
+                fp=None,
+            ),
+            (
+                'POST request to controller failed due to error: '
+                'HTTP Error 500: Internal Server Error'
+            ),
+        ),
+        (
+            urllib2.URLError('Connection refused'),
+            (
+                'POST request to controller failed due to error: '
+                '<urlopen error Connection refused>'
+            )
+        ),
+    ]
 
-    with tempfile.NamedTemporaryFile() as tmp:
-        agent = MockAgent(port=12345)
-        agent.setup_logging(tmp.name)
-        agent.collect_server_metadata()
+    for error, msg in output:
+        def mock_urlopen(request, timeout=5):
+            raise error
 
-        agent.controller_url = 'http://mock/api/status/'
+        with tempfile.NamedTemporaryFile() as tmp:
+            agent = MockAgent(port=12345)
+            agent.setup_logging(tmp.name)
+            agent.collect_server_metadata()
 
-        with mock.patch('urllib2.urlopen', mock_urlopen):
-            agent.status_to_controller()
+            agent.controller_url = 'http://mock/api/status/'
 
-        tmp.seek(0)
-        contents = tmp.read()
+            with mock.patch('urllib2.urlopen', mock_urlopen):
+                agent.status_to_controller()
 
-        msg = (
-            'POST request to controller failed due to error: '
-            'HTTP Error 500: Internal Server Error'
-        )
+            tmp.seek(0)
+            contents = tmp.read()
 
-        assert msg in contents, (
-            'Expected %s in logs, got:\n%s' % (msg, contents)
-        )
+            assert msg in contents, (
+                'Expected %s in logs, got:\n%s' % (msg, contents)
+            )

--- a/agents/tests/test_agent.py
+++ b/agents/tests/test_agent.py
@@ -1,0 +1,27 @@
+import tempfile
+
+import mock
+
+from agents.smtp import smtp
+
+
+def test_to_controller_success():
+    def mock_urlopen(request, timeout=5):
+        class MockResponse(object):
+            def getcode(self):
+                return 201
+        return MockResponse()
+
+    with tempfile.NamedTemporaryFile() as tmp:
+        agent = smtp.SMTPAgent(log_path=tmp.name)
+        agent.controller_url = 'mock/api/status/'
+
+        with mock.patch('urllib2.urlopen', mock_urlopen):
+            agent.to_controller()
+
+        tmp.seek(0)
+        contents = tmp.read()
+
+        assert 'POST request status: 201' in contents, (
+            'POST request test failed'
+        )

--- a/agents/tests/test_agent.py
+++ b/agents/tests/test_agent.py
@@ -1,6 +1,7 @@
 import tempfile
 
 import mock
+import pytest
 
 from agents.agent import ServerAgent
 
@@ -20,8 +21,21 @@ class MockAgent(ServerAgent):
         )
 
 
-# def test_agent_type_checks():
-#     ...
+def test_type_checks_on_init():
+    with pytest.raises(TypeError):
+        MockAgent(port='invalid')
+
+    with pytest.raises(TypeError):
+        MockAgent(processes=0)
+
+
+def test_type_checks_on_config_parse():
+    with tempfile.NamedTemporaryFile() as tmp:
+        tmp.write('[server]\nname=mock\nport=invalid\nprocesses=proc1')
+        tmp.flush()
+
+        with pytest.raises(TypeError):
+            MockAgent.from_config_file(tmp.name)
 
 
 def test_status_to_controller_success():

--- a/agents/tests/test_agent.py
+++ b/agents/tests/test_agent.py
@@ -1,3 +1,4 @@
+import socket
 import tempfile
 
 import mock
@@ -75,8 +76,8 @@ def test_status_to_controller_success():
 
 def test_status_to_controller_error():
     """
-    Test that the HTTP failure of POST request to controller is properly
-    handled and logged.
+    Test that the HTTP and URL failures of POST request to controller are
+    properly handled and logged.
     """
     output = [
         (
@@ -97,7 +98,14 @@ def test_status_to_controller_error():
             (
                 'POST request to controller failed due to error: '
                 '<urlopen error Connection refused>'
-            )
+            ),
+        ),
+        (
+            socket.timeout('HTTP request timed out'),
+            (
+                'POST request to controller failed due to error: '
+                'HTTP request timed out'
+            ),
         ),
     ]
 

--- a/agents/tests/test_agent.py
+++ b/agents/tests/test_agent.py
@@ -1,3 +1,4 @@
+import os
 import socket
 import tempfile
 import types
@@ -22,6 +23,19 @@ class MockAgent(ServerAgent):
         super(MockAgent, self).__init__(
             server_name, port, processes, controller_url, config_file
         )
+
+    def setup_logging(self, path=None):
+        if not path:
+            self.logfile = tempfile.NamedTemporaryFile(delete=False)
+            self.logfile.close()
+
+            path = self.logfile.name
+
+        return super(MockAgent, self).setup_logging(path)
+
+    def __del__(self):
+        if self.log_path:
+            os.remove(self.log_path)
 
 
 def test_type_checks_on_init():
@@ -51,31 +65,30 @@ def test_status_to_json_type_error():
         def __str__(self):
             raise TypeError("Can't serialize me")
 
-    with tempfile.NamedTemporaryFile() as tmp:
-        agent = MockAgent(port=12345)
-        agent.setup_logging(tmp.name)
+    def mock_status_to_dict(self):
+        status = ServerAgent.status_to_dict(self)
+        status.update({'mock_parameter': MockUnserializableParameter()})
+        return status
 
-        def mock_status_to_dict(self):
-            status = ServerAgent.status_to_dict(self)
-            status.update({'mock_parameter': MockUnserializableParameter()})
+    agent = MockAgent(port=12345)
+    agent.setup_logging()
 
-            return status
+    agent.status_to_dict = types.MethodType(mock_status_to_dict, agent)
 
-        agent.status_to_dict = types.MethodType(mock_status_to_dict, agent)
+    agent.status_to_json()
 
-        agent.status_to_json()
+    with open(agent.logfile.name, 'r') as f:
+        f.seek(0)
+        contents = f.read()
 
-        tmp.seek(0)
-        contents = tmp.read()
+    msg = (
+        'JSON serialization of status failed due to error: '
+        "Can't serialize me"
+    )
 
-        msg = (
-            'JSON serialization of status failed due to error: '
-            "Can't serialize me"
-        )
-
-        assert msg in contents, (
-            'Expected %s in logs, got:\n%s' % (msg, contents)
-        )
+    assert msg in contents, (
+        'Expected %s in logs, got:\n%s' % (msg, contents)
+    )
 
 
 def test_status_to_controller_success():
@@ -89,45 +102,45 @@ def test_status_to_controller_success():
                 return 201
         return MockResponse()
 
-    with tempfile.NamedTemporaryFile() as tmp:
-        agent = MockAgent(port=12345)
-        agent.setup_logging(tmp.name)
-        agent.collect_server_metadata()
+    agent = MockAgent(port=12345)
+    agent.setup_logging()
+    agent.collect_server_metadata()
 
-        agent.controller_url = 'http://mock/api/status/'
+    agent.controller_url = 'http://mock/api/status/'
 
-        with mock.patch('urllib2.urlopen', mock_urlopen):
-            agent.status_to_controller()
+    with mock.patch('urllib2.urlopen', mock_urlopen):
+        agent.status_to_controller()
 
-        tmp.seek(0)
-        contents = tmp.read()
+    with open(agent.logfile.name, 'r') as f:
+        f.seek(0)
+        contents = f.read()
 
-        assert 'POST request status: 201' in contents, (
-            'Expected "POST request status: 201" in logs, got:\n%s' % contents
-        )
+    assert 'POST request status: 201' in contents, (
+        'Expected "POST request status: 201" in logs, got:\n%s' % contents
+    )
 
 
 def test_status_to_controller_missing_url():
     """Test that missing controller URL is properly handled and logged."""
-    with tempfile.NamedTemporaryFile() as tmp:
-        agent = MockAgent(port=12345)
-        agent.setup_logging(tmp.name)
-        agent.collect_server_metadata()
+    agent = MockAgent(port=12345)
+    agent.setup_logging()
+    agent.collect_server_metadata()
 
-        # Set controller's URL explicitly to be independent of changes
-        # of default values in agent.py/
-        agent.controller_url = None
+    # Set controller's URL explicitly to be independent of changes
+    # of default values in agent.py/
+    agent.controller_url = None
 
-        agent.status_to_controller()
+    agent.status_to_controller()
 
-        tmp.seek(0)
-        contents = tmp.read()
+    with open(agent.logfile.name, 'r') as f:
+        f.seek(0)
+        contents = f.read()
 
-        msg = "Couldn't send status update: controller URL is not set"
+    msg = "Couldn't send status update: controller URL is not set"
 
-        assert msg in contents, (
-            'Expected %s in logs, got:\n%s' % (msg, contents)
-        )
+    assert msg in contents, (
+        'Expected %s in logs, got:\n%s' % (msg, contents)
+    )
 
 
 def test_status_to_controller_error():
@@ -169,19 +182,19 @@ def test_status_to_controller_error():
         def mock_urlopen(request, timeout=5):
             raise error
 
-        with tempfile.NamedTemporaryFile() as tmp:
-            agent = MockAgent(port=12345)
-            agent.setup_logging(tmp.name)
-            agent.collect_server_metadata()
+        agent = MockAgent(port=12345)
+        agent.setup_logging()
+        agent.collect_server_metadata()
 
-            agent.controller_url = 'http://mock/api/status/'
+        agent.controller_url = 'http://mock/api/status/'
 
-            with mock.patch('urllib2.urlopen', mock_urlopen):
-                agent.status_to_controller()
+        with mock.patch('urllib2.urlopen', mock_urlopen):
+            agent.status_to_controller()
 
-            tmp.seek(0)
-            contents = tmp.read()
+        with open(agent.logfile.name, 'r') as f:
+            f.seek(0)
+            contents = f.read()
 
-            assert msg in contents, (
-                'Expected %s in logs, got:\n%s' % (msg, contents)
-            )
+        assert msg in contents, (
+            'Expected %s in logs, got:\n%s' % (msg, contents)
+        )

--- a/agents/tests/test_agent.py
+++ b/agents/tests/test_agent.py
@@ -2,7 +2,26 @@ import tempfile
 
 import mock
 
-from agents.smtp import smtp
+from agents.agent import ServerAgent
+
+
+class MockAgent(ServerAgent):
+
+    def __init__(
+        self,
+        server_name='mock',
+        port=None,
+        processes=None,
+        controller_url=None,
+        config_file=None,
+    ):
+        super(MockAgent, self).__init__(
+            server_name, port, processes, controller_url, config_file
+        )
+
+
+# def test_agent_type_checks():
+#     ...
 
 
 def test_status_to_controller_success():
@@ -13,8 +32,11 @@ def test_status_to_controller_success():
         return MockResponse()
 
     with tempfile.NamedTemporaryFile() as tmp:
-        agent = smtp.SMTPAgent(log_path=tmp.name)
-        agent.controller_url = 'mock/api/status/'
+        agent = MockAgent(port=12345)
+        agent.setup_logging(tmp.name)
+        agent.collect_server_metadata()
+
+        agent.controller_url = 'http://mock/api/status/'
 
         with mock.patch('urllib2.urlopen', mock_urlopen):
             agent.status_to_controller()

--- a/agents/tests/test_agent.py
+++ b/agents/tests/test_agent.py
@@ -1,5 +1,6 @@
 import socket
 import tempfile
+import types
 
 import mock
 import pytest
@@ -43,6 +44,38 @@ def test_type_checks_on_config_parse():
 
         with pytest.raises(TypeError):
             MockAgent.from_config_file(tmp.name)
+
+
+def test_status_to_json_type_error():
+    class MockUnserializableParameter:
+        def __str__(self):
+            raise TypeError("Can't serialize me")
+
+    with tempfile.NamedTemporaryFile() as tmp:
+        agent = MockAgent(port=12345)
+        agent.setup_logging(tmp.name)
+
+        def mock_status_to_dict(self):
+            status = ServerAgent.status_to_dict(self)
+            status.update({'mock_parameter': MockUnserializableParameter()})
+
+            return status
+
+        agent.status_to_dict = types.MethodType(mock_status_to_dict, agent)
+
+        agent.status_to_json()
+
+        tmp.seek(0)
+        contents = tmp.read()
+
+        msg = (
+            'JSON serialization of status failed due to error: '
+            "Can't serialize me"
+        )
+
+        assert msg in contents, (
+            'Expected %s in logs, got:\n%s' % (msg, contents)
+        )
 
 
 def test_status_to_controller_success():

--- a/agents/tests/test_agent.py
+++ b/agents/tests/test_agent.py
@@ -17,7 +17,7 @@ def test_to_controller_success():
         agent.controller_url = 'mock/api/status/'
 
         with mock.patch('urllib2.urlopen', mock_urlopen):
-            agent.to_controller()
+            agent.status_to_controller()
 
         tmp.seek(0)
         contents = tmp.read()

--- a/agents/tests/test_agent.py
+++ b/agents/tests/test_agent.py
@@ -59,5 +59,5 @@ def test_status_to_controller_success():
         contents = tmp.read()
 
         assert 'POST request status: 201' in contents, (
-            'POST request test failed'
+            'Expected "POST request status: 201" in logs, got:\n%s' % contents
         )

--- a/agents/utils/helpers.py
+++ b/agents/utils/helpers.py
@@ -39,7 +39,19 @@ def get_config_option(
         value = config.get(section, option)
 
         if cast:
-            value = cast(value)
+            try:
+                value = cast(value)
+            except (TypeError, ValueError) as e:
+                maybe_log_message(
+                    (
+                        'Could not cast option value '
+                        '%s due to error: %s' % (value, str(e))
+                    ),
+                    logger,
+                    fallback_logger=fallback_logger,
+                )
+                return value
+
     except (ConfigParser.NoSectionError, ConfigParser.NoOptionError) as e:
         if logger:
             maybe_log_message(

--- a/agents/utils/helpers.py
+++ b/agents/utils/helpers.py
@@ -6,7 +6,13 @@ from .logtools import maybe_log_message
 
 
 def get_config_option(
-    config, section, option, default=None, logger=None, fallback_logger=None
+    config,
+    section,
+    option,
+    default=None,
+    logger=None,
+    fallback_logger=None,
+    cast=None,
 ):
     """
     Helper function to get a config option from a config parser falling
@@ -30,7 +36,10 @@ def get_config_option(
         option-names are case-insensitive.
     """
     try:
-        return config.get(section, option)
+        value = config.get(section, option)
+
+        if cast:
+            value = cast(value)
     except (ConfigParser.NoSectionError, ConfigParser.NoOptionError) as e:
         if logger:
             maybe_log_message(
@@ -39,4 +48,4 @@ def get_config_option(
                 fallback_logger=fallback_logger,
                 level=logging.WARNING,
             )
-    return default
+    return value or default

--- a/agents/utils/helpers.py
+++ b/agents/utils/helpers.py
@@ -27,6 +27,12 @@ def get_config_option(
         logger (logging.Logger): Primary logger. Default is None (no logging).
         fallback_logger (logging.Logger): Fallback logger. Default is
             None.
+        cast (Callable): Callable to convert the option value to a required
+            type or form. For example, use `int` for integers and `float`
+            for floats. To implement custom logic, a lambda-function
+            should be passed. On cast failure or if cast function is not
+            provided, the original string returned by ConfigParser will
+            be returned. Default is None.
 
     Returns:
         Any: Option value.

--- a/agents/utils/logconfig.ini
+++ b/agents/utils/logconfig.ini
@@ -33,7 +33,7 @@ args=(sys.stdout,)
 class=agents.utils.logtools.CustomTimedRotatingHandler
 level=INFO
 formatter=detailed
-args=('%(log_dir)s/agent.log',)
+args=('%(log_path)s',)
 
 [formatter_minimal]
 format=%(levelname)s : %(message)s

--- a/agents/utils/logtools.py
+++ b/agents/utils/logtools.py
@@ -39,7 +39,7 @@ def maybe_make_dir(path):
                 raise
 
 
-class CustomTimedRotatingHandler(TimedRotatingFileHandler):
+class CustomTimedRotatingHandler(TimedRotatingFileHandler, object):
 
     def __init__(
         self,


### PR DESCRIPTION
Primary issue addressed in this PR:

- **Implement agent functionality to send POST request with metadata to controller.** This is implemented in the base `ServerAgent` by `status_to_controller` method. Although children agents may later extend the parent status dict with extra parameters,`status_to_controller ` will always acquire the metadata of the caller.

    Currently, `status_to_controller ` has two optional parameters:
        - `timeout`: self-explanatory
        - `api_key`: this is an important one. Since Python 2.6 doesn't support SSL, we will have to think about how to ensure secure communication between agents and controller. By introducing an `api_key` parameter, I suggest to do this via authorization tokens. In fact, @mehalyna has today created a new issue where it is suggested this is implemented.
    
    `status_to_controller` comes together with a unit test `test_status_to_controller_success` relying on a mocked HTTP response object `MockResponse`.

Secondary issues include:

- **Made configuring agents more flexible.** Agent configurations which currently include `server_name`, `port`, `processes`, `controller_url`, `config_file` and `log_path` can now be configured via a config file or via the constructor. If not provided, default values set as class attributes will be set. **Note** that while it is possible to pass some options in a config file and other in the constructor, it is not recommended, as it will simply be confusing and will require deep understanding of the agent logic by the programmer.
- **Added  optional `cast` argument to `get_config_option`.** This is a derivative of the previous bullet point. When we read config options from a config file, `ConfigParser` will always return strings. Passing an appropriate cast function, i.e., `int` for integers, `float` for floats, `lambda` for custom logic, will allow us to ensure all attributes have correct type and form.
- **Minor refactoring.** Originally there have been methods like `to_dict`, `to_json`, `to_txt`. I've renamed them to `status_to_dict`, `status_to_json` and `status_to_txt`, respectively. The new names are simply more accurate, since these methods only operate on status data - not on all data that an agent may want to log.

**NOTE:** while I believe that this PR is in a finalized condition at the moment, it depends on [Nazar's PR](https://github.com/ITA-Dnipro/PyDataCenter5000/pull/50) which offers an implementation of controller. Therefore, I think his PR should be reviewed and merged first and this PR should and will be tested against the actual controller once it's done.