### PR TITLE
9 - Add Agent Error Handling and Retry Logic (Python 2.6) & Tests

### DIFF
--- a/agents/agent.py
+++ b/agents/agent.py
@@ -23,10 +23,11 @@ log_config_path = pkg_resources.resource_filename(
 
 MAX_RETRIES = 3
 RETRY_DELAY = 5
+LOG_FILE = 'agent_log.txt'
 
 
 def log_error(msg):
-    with open('agent_log.txt', 'a') as f:
+    with open(LOG_FILE, 'a') as f:
         timestamp = time.strftime('%Y-%m-%d %H:%M:%S')
         f.write('[ERROR] %s - %s\n' % (timestamp, msg))
 
@@ -63,11 +64,14 @@ def post_data(url, data, max_retries=MAX_RETRIES, delay=RETRY_DELAY):
                 log_error(
                     'Retrying in %d seconds...' % delay
                 )
-                time.sleep(delay)
+                time.sleep(delay * attempt)
             else:
                 log_error(
                     'All %d attempts failed. Data not sent. '
                     'Last error: %s' % (max_retries, e)
+                )
+                raise RuntimeError(
+                    'POST failed after %d attempts' % max_retries
                 )
 
 

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -438,7 +438,6 @@ class ServerAgent(object):
                         'POST failed after %d attempts' % max_retries
                     )
 
-
     def status_to_controller(self, timeout=5, api_key=None):
         """
         Send system's metadata to controller.

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -21,8 +21,11 @@ log_config_path = pkg_resources.resource_filename(
     'agents.utils.logtools', 'logconfig.ini'
 )
 
-MAX_RETRIES = 3
-RETRY_DELAY = 5
+config = ConfigParser.ConfigParser()
+config.read('config.ini')
+
+MAX_RETRIES = config.getint('retry_settings', 'max_retries')
+RETRY_DELAY = config.getint('retry_settings', 'retry_delay')
 
 
 def get_ip_from_interface(interface):

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -23,13 +23,6 @@ log_config_path = pkg_resources.resource_filename(
 
 MAX_RETRIES = 3
 RETRY_DELAY = 5
-LOG_FILE = 'agent_log.txt'
-
-
-def log_error(msg):
-    with open(LOG_FILE, 'a') as f:
-        timestamp = time.strftime('%Y-%m-%d %H:%M:%S')
-        f.write('[ERROR] %s - %s\n' % (timestamp, msg))
 
 
 def get_ip_from_interface(interface):
@@ -407,32 +400,54 @@ class ServerAgent(object):
 
         for attempt in range(1, max_retries + 1):
             try:
-                log_error(
-                    '[Attempt %d] Sending data to %s' % (attempt, url)
+                maybe_log_message(
+                    '[Attempt %d] Sending data to %s' % (attempt, url),
+                    logger=self.logger,
+                    fallback_logger=self.fallback_logger,
+                    level=logging.INFO
                 )
                 request = urllib2.Request(
                     url, data=payload, headers=headers
                 )
                 response = urllib2.urlopen(request)
                 result = response.read()
+                status_code = response.getcode()
+                maybe_log_message(
+                    'POST request status: %d' % status_code,
+                    logger=self.logger,
+                    fallback_logger=self.fallback_logger,
+                    level=logging.INFO
+                )
                 response.close()
-                log_error(
-                    'Success on attempt %d: %s' % (attempt, result)
+                maybe_log_message(
+                    'Success on attempt %d: %s' % (attempt, result),
+                    logger=self.logger,
+                    fallback_logger=self.fallback_logger,
+                    level=logging.INFO
                 )
                 return result
             except urllib2.URLError as e:
-                log_error(
-                    'Attempt %d failed: %s' % (attempt, e)
+                maybe_log_message(
+                    'Attempt %d failed: %s' % (attempt, e),
+                    logger=self.logger,
+                    fallback_logger=self.fallback_logger,
+                    level=logging.ERROR
                 )
                 if attempt < max_retries:
-                    log_error(
-                        'Retrying in %d seconds...' % delay
+                    maybe_log_message(
+                        'Retrying in %d seconds...' % delay,
+                        logger=self.logger,
+                        fallback_logger=self.fallback_logger,
+                        level=logging.WARNING
                     )
                     time.sleep(delay * attempt)
                 else:
-                    log_error(
+                    maybe_log_message(
                         'All %d attempts failed. Data not sent. '
-                        'Last error: %s' % (max_retries, e)
+                        'Last error: %s' % (max_retries, e),
+                        logger=self.logger,
+                        fallback_logger=self.fallback_logger,
+                        level=logging.CRITICAL
                     )
                     raise RuntimeError(
                         'POST failed after %d attempts' % max_retries

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -3,11 +3,11 @@ import datetime
 import json
 import logging
 import logging.config
+import os
 import platform
 import socket
 import subprocess
 import time
-import os
 from collections import Sequence
 
 import ConfigParser

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -7,6 +7,7 @@ import platform
 import socket
 import subprocess
 import time
+import os
 from collections import Sequence
 
 import ConfigParser
@@ -21,8 +22,9 @@ log_config_path = pkg_resources.resource_filename(
     'agents.utils.logtools', 'logconfig.ini'
 )
 
+config_path = os.path.join(os.path.dirname(__file__), 'config.ini')
 config = ConfigParser.ConfigParser()
-config.read('config.ini')
+config.read(config_path)
 
 MAX_RETRIES = config.getint('retry_settings', 'max_retries')
 RETRY_DELAY = config.getint('retry_settings', 'retry_delay')

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -7,6 +7,7 @@ import platform
 import socket
 import subprocess
 from collections import Sequence
+import time
 
 import ConfigParser
 import pkg_resources
@@ -19,6 +20,55 @@ from .utils.logtools import maybe_log_message
 log_config_path = pkg_resources.resource_filename(
     'agents.utils.logtools', 'logconfig.ini'
 )
+
+MAX_RETRIES = 3
+RETRY_DELAY = 5
+
+
+def log_error(msg):
+    with open('agent_log.txt', 'a') as f:
+        timestamp = time.strftime('%Y-%m-%d %H:%M:%S')
+        f.write("[ERROR] %s - %s\n" % (timestamp, msg))
+
+
+def post_data(url, data, max_retries=MAX_RETRIES, delay=RETRY_DELAY):
+    """
+    Sends a POST request with JSON data to the specified URL
+    with retry logic. Retries up to `max_retries` times with `delay`
+    seconds between attempts. Logs all attempts and failures.
+    """
+    headers = {'Content-Type': 'application/json'}
+    payload = json.dumps(data).encode('utf-8')
+
+    for attempt in range(1, max_retries + 1):
+        try:
+            log_error(
+                "[Attempt %d] Sending data to %s" % (attempt, url)
+            )
+            request = urllib2.Request(
+                url, data=payload, headers=headers
+            )
+            response = urllib2.urlopen(request)
+            result = response.read()
+            response.close()
+            log_error(
+                "Success on attempt %d: %s" % (attempt, result)
+            )
+            return result
+        except urllib2.URLError as e:
+            log_error(
+                "Attempt %d failed: %s" % (attempt, e)
+            )
+            if attempt < max_retries:
+                log_error(
+                    "Retrying in %d seconds..." % delay
+                )
+                time.sleep(delay)
+            else:
+                log_error(
+                    "All %d attempts failed. Data not sent. "
+                    "Last error: %s" % (max_retries, e)
+                )
 
 
 def get_ip_from_interface(interface):
@@ -402,35 +452,33 @@ class ServerAgent(object):
 
             return
 
-        payload = self.status_to_json(log=False)
+        payload_str = self.status_to_json(log=False)
+        payload = json.loads(payload_str)
 
         headers = {'Content-Type': 'application/json'}
         if api_key:
-            headers.update({'X-API-Key': api_key})
-
-        request = urllib2.Request(
-            self.controller_url, payload, headers=headers
-        )
-
-        status_code = None
+            payload['api_key'] = api_key
 
         try:
-            response = urllib2.urlopen(request, timeout=timeout)
-            status_code = response.getcode()
-        except (urllib2.URLError, urllib2.HTTPError, socket.timeout) as e:
-            status_code = getattr(e, 'code', None)
-
-            maybe_log_message(
-                'POST request to controller failed due to error: %s' % str(e),
-                logger=self.logger,
-                fallback_logger=self.fallback_logger,
-                exc_info=True,
-            )
-        finally:
-            if status_code:
+            result = post_data(self.controller_url, payload)
+            if result:
                 maybe_log_message(
-                    'POST request status: %s' % str(status_code),
+                    'POST request to controller succeeded.',
                     logger=self.logger,
                     fallback_logger=self.fallback_logger,
                     level=logging.INFO,
                 )
+            else:
+                maybe_log_message(
+                    'POST request to controller failed after retries.',
+                    logger=self.logger,
+                    fallback_logger=self.fallback_logger,
+                    exc_info=True,
+                )
+        except Exception as e:
+            maybe_log_message(
+                'Unexpected error during status update: %s' % str(e),
+                logger=self.logger,
+                fallback_logger=self.fallback_logger,
+                exc_info=True,
+            )

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -28,6 +28,8 @@ config.read(config_path)
 
 MAX_RETRIES = config.getint('retry_settings', 'max_retries')
 RETRY_DELAY = config.getint('retry_settings', 'retry_delay')
+HTTP_TIMEOUT = config.getint('retry_settings', 'http_timeout')
+AUTH_TOKEN_TYPE = 'Bearer'
 
 
 def get_ip_from_interface(interface):
@@ -394,13 +396,26 @@ class ServerAgent(object):
                 fallback_logger=self.fallback_logger,
             )
 
-    def post_data(self, url, data, max_retries=MAX_RETRIES, delay=RETRY_DELAY):
+    def post_data(
+        self,
+        url,
+        data,
+        auth_token_type=AUTH_TOKEN_TYPE,
+        api_key=None,
+        max_retries=MAX_RETRIES,
+        delay=RETRY_DELAY,
+        timeout=HTTP_TIMEOUT
+    ):
         """
         Sends a POST request with JSON data to the specified URL
         with retry logic. Retries up to `max_retries` times with `delay`
         seconds between attempts. Logs all attempts and failures.
         """
         headers = {'Content-Type': 'application/json'}
+        if api_key:
+            headers.update(
+                {'Authorization': '%s %s' % (auth_token_type, api_key)}
+            )
         payload = json.dumps(data).encode('utf-8')
 
         for attempt in range(1, max_retries + 1):
@@ -414,7 +429,7 @@ class ServerAgent(object):
                 request = urllib2.Request(
                     url, data=payload, headers=headers
                 )
-                response = urllib2.urlopen(request)
+                response = urllib2.urlopen(request, timeout=timeout)
                 result = response.read()
                 status_code = response.getcode()
                 maybe_log_message(
@@ -458,13 +473,26 @@ class ServerAgent(object):
                         'POST failed after %d attempts' % max_retries
                     )
 
-    def status_to_controller(self, timeout=5, api_key=None):
+    def status_to_controller(
+        self,
+        auth_token_type=AUTH_TOKEN_TYPE,
+        api_key=None,
+        max_retries=MAX_RETRIES,
+        delay=RETRY_DELAY,
+        timeout=HTTP_TIMEOUT
+    ):
         """
-        Send system's metadata to controller.
+        Sends a POST request with JSON data to the specified URL,
+        including optional authentication, and with built-in retry logic.
 
         Parameters:
-            timeout (int): POST request timeout in seconds. Default is 5.
-            api_key (str): Authentication API key. Default is None.
+            url (str): Target URL for the POST request.
+            data (dict): Data to send as JSON payload.
+            auth_token_type (str): Token type prefix for the Authorization header (e.g., 'Bearer').
+            api_key (str): API key to be used for the Authorization header. If None, no auth header is added.
+            max_retries (int): Maximum number of retry attempts on failure. Default is MAX_RETRIES.
+            delay (int | float): Delay (in seconds) between retry attempts. Default is RETRY_DELAY.
+            timeout (int | float): Timeout (in seconds) for the request. Default is HTTP_TIMEOUT.
         """
         if not self.controller_url:
             maybe_log_message(
@@ -477,11 +505,16 @@ class ServerAgent(object):
         payload_str = self.status_to_json(log=False)
         payload = json.loads(payload_str)
 
-        if api_key:
-            payload['api_key'] = api_key
-
         try:
-            result = self.post_data(self.controller_url, payload)
+            result = self.post_data(
+                self.controller_url,
+                payload,
+                auth_token_type,
+                api_key,
+                max_retries,
+                delay,
+                timeout
+            )
             if result:
                 maybe_log_message(
                     'POST request to controller succeeded.',

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -29,7 +29,7 @@ config.read(config_path)
 MAX_RETRIES = config.getint('retry_settings', 'max_retries')
 RETRY_DELAY = config.getint('retry_settings', 'retry_delay')
 HTTP_TIMEOUT = config.getint('retry_settings', 'http_timeout')
-AUTH_TOKEN_TYPE = 'Bearer'
+AUTH_TOKEN_TYPE = config.get('general', 'auth_token_type')
 
 
 def get_ip_from_interface(interface):
@@ -482,17 +482,19 @@ class ServerAgent(object):
         timeout=HTTP_TIMEOUT
     ):
         """
-        Sends a POST request with JSON data to the specified URL,
-        including optional authentication, and with built-in retry logic.
+        Sends a POST request with JSON data to the specified URL, including
+        optional authentication, and with built-in retry logic.
 
         Parameters:
             url (str): Target URL for the POST request.
             data (dict): Data to send as JSON payload.
-            auth_token_type (str): Token type prefix for the Authorization header (e.g., 'Bearer').
-            api_key (str): API key to be used for the Authorization header. If None, no auth header is added.
-            max_retries (int): Maximum number of retry attempts on failure. Default is MAX_RETRIES.
-            delay (int | float): Delay (in seconds) between retry attempts. Default is RETRY_DELAY.
-            timeout (int | float): Timeout (in seconds) for the request. Default is HTTP_TIMEOUT.
+            auth_token_type (str): Token type prefix for the Authorization
+                header (e.g., 'Bearer').
+            api_key (str): API key to be used for the Authorization header. If
+                None, no auth header is added.
+            max_retries (int): Maximum number of retry attempts on failure.
+                Default is MAX_RETRIES.
+            delay (int | float): Delay (in seconds) between
         """
         if not self.controller_url:
             maybe_log_message(

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -32,49 +32,6 @@ def log_error(msg):
         f.write('[ERROR] %s - %s\n' % (timestamp, msg))
 
 
-def post_data(url, data, max_retries=MAX_RETRIES, delay=RETRY_DELAY):
-    """
-    Sends a POST request with JSON data to the specified URL
-    with retry logic. Retries up to `max_retries` times with `delay`
-    seconds between attempts. Logs all attempts and failures.
-    """
-    headers = {'Content-Type': 'application/json'}
-    payload = json.dumps(data).encode('utf-8')
-
-    for attempt in range(1, max_retries + 1):
-        try:
-            log_error(
-                '[Attempt %d] Sending data to %s' % (attempt, url)
-            )
-            request = urllib2.Request(
-                url, data=payload, headers=headers
-            )
-            response = urllib2.urlopen(request)
-            result = response.read()
-            response.close()
-            log_error(
-                'Success on attempt %d: %s' % (attempt, result)
-            )
-            return result
-        except urllib2.URLError as e:
-            log_error(
-                'Attempt %d failed: %s' % (attempt, e)
-            )
-            if attempt < max_retries:
-                log_error(
-                    'Retrying in %d seconds...' % delay
-                )
-                time.sleep(delay * attempt)
-            else:
-                log_error(
-                    'All %d attempts failed. Data not sent. '
-                    'Last error: %s' % (max_retries, e)
-                )
-                raise RuntimeError(
-                    'POST failed after %d attempts' % max_retries
-                )
-
-
 def get_ip_from_interface(interface):
     """
     Attempt getting server's primary IP address associated with a given
@@ -439,6 +396,49 @@ class ServerAgent(object):
                 fallback_logger=self.fallback_logger,
             )
 
+    def post_data(self, url, data, max_retries=MAX_RETRIES, delay=RETRY_DELAY):
+        """
+        Sends a POST request with JSON data to the specified URL
+        with retry logic. Retries up to `max_retries` times with `delay`
+        seconds between attempts. Logs all attempts and failures.
+        """
+        headers = {'Content-Type': 'application/json'}
+        payload = json.dumps(data).encode('utf-8')
+
+        for attempt in range(1, max_retries + 1):
+            try:
+                log_error(
+                    '[Attempt %d] Sending data to %s' % (attempt, url)
+                )
+                request = urllib2.Request(
+                    url, data=payload, headers=headers
+                )
+                response = urllib2.urlopen(request)
+                result = response.read()
+                response.close()
+                log_error(
+                    'Success on attempt %d: %s' % (attempt, result)
+                )
+                return result
+            except urllib2.URLError as e:
+                log_error(
+                    'Attempt %d failed: %s' % (attempt, e)
+                )
+                if attempt < max_retries:
+                    log_error(
+                        'Retrying in %d seconds...' % delay
+                    )
+                    time.sleep(delay * attempt)
+                else:
+                    log_error(
+                        'All %d attempts failed. Data not sent. '
+                        'Last error: %s' % (max_retries, e)
+                    )
+                    raise RuntimeError(
+                        'POST failed after %d attempts' % max_retries
+                    )
+
+
     def status_to_controller(self, timeout=5, api_key=None):
         """
         Send system's metadata to controller.
@@ -463,7 +463,7 @@ class ServerAgent(object):
             payload['api_key'] = api_key
 
         try:
-            result = post_data(self.controller_url, payload)
+            result = self.post_data(self.controller_url, payload)
             if result:
                 maybe_log_message(
                     'POST request to controller succeeded.',

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -467,7 +467,6 @@ class ServerAgent(object):
                 logger=self.logger,
                 fallback_logger=self.fallback_logger,
             )
-
             return
 
         payload_str = self.status_to_json(log=False)
@@ -492,6 +491,13 @@ class ServerAgent(object):
                     fallback_logger=self.fallback_logger,
                     exc_info=True,
                 )
+        except (urllib2.HTTPError, urllib2.URLError, socket.timeout) as e:
+            maybe_log_message(
+                f'POST request to controller failed due to error: {str(e)}',
+                logger=self.logger,
+                fallback_logger=self.fallback_logger,
+                exc_info=True,
+            )
         except Exception as e:
             maybe_log_message(
                 'Unexpected error during status update: %s' % str(e),

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -493,7 +493,7 @@ class ServerAgent(object):
                 )
         except (urllib2.HTTPError, urllib2.URLError, socket.timeout) as e:
             maybe_log_message(
-                'POST request to controller failed due to error: ' % str(e),
+                'POST request to controller failed due to error: %s' % str(e),
                 logger=self.logger,
                 fallback_logger=self.fallback_logger,
                 exc_info=True,

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -493,7 +493,7 @@ class ServerAgent(object):
                 )
         except (urllib2.HTTPError, urllib2.URLError, socket.timeout) as e:
             maybe_log_message(
-                f'POST request to controller failed due to error: {str(e)}',
+                'POST request to controller failed due to error: ' % str(e),
                 logger=self.logger,
                 fallback_logger=self.fallback_logger,
                 exc_info=True,

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -6,8 +6,8 @@ import logging.config
 import platform
 import socket
 import subprocess
-from collections import Sequence
 import time
+from collections import Sequence
 
 import ConfigParser
 import pkg_resources
@@ -28,7 +28,7 @@ RETRY_DELAY = 5
 def log_error(msg):
     with open('agent_log.txt', 'a') as f:
         timestamp = time.strftime('%Y-%m-%d %H:%M:%S')
-        f.write("[ERROR] %s - %s\n" % (timestamp, msg))
+        f.write('[ERROR] %s - %s\n' % (timestamp, msg))
 
 
 def post_data(url, data, max_retries=MAX_RETRIES, delay=RETRY_DELAY):
@@ -43,7 +43,7 @@ def post_data(url, data, max_retries=MAX_RETRIES, delay=RETRY_DELAY):
     for attempt in range(1, max_retries + 1):
         try:
             log_error(
-                "[Attempt %d] Sending data to %s" % (attempt, url)
+                '[Attempt %d] Sending data to %s' % (attempt, url)
             )
             request = urllib2.Request(
                 url, data=payload, headers=headers
@@ -52,22 +52,22 @@ def post_data(url, data, max_retries=MAX_RETRIES, delay=RETRY_DELAY):
             result = response.read()
             response.close()
             log_error(
-                "Success on attempt %d: %s" % (attempt, result)
+                'Success on attempt %d: %s' % (attempt, result)
             )
             return result
         except urllib2.URLError as e:
             log_error(
-                "Attempt %d failed: %s" % (attempt, e)
+                'Attempt %d failed: %s' % (attempt, e)
             )
             if attempt < max_retries:
                 log_error(
-                    "Retrying in %d seconds..." % delay
+                    'Retrying in %d seconds...' % delay
                 )
                 time.sleep(delay)
             else:
                 log_error(
-                    "All %d attempts failed. Data not sent. "
-                    "Last error: %s" % (max_retries, e)
+                    'All %d attempts failed. Data not sent. '
+                    'Last error: %s' % (max_retries, e)
                 )
 
 
@@ -455,7 +455,6 @@ class ServerAgent(object):
         payload_str = self.status_to_json(log=False)
         payload = json.loads(payload_str)
 
-        headers = {'Content-Type': 'application/json'}
         if api_key:
             payload['api_key'] = api_key
 

--- a/agents/config.ini
+++ b/agents/config.ini
@@ -1,0 +1,3 @@
+[retry_settings]
+max_retries = 3
+retry_delay = 5

--- a/agents/config.ini
+++ b/agents/config.ini
@@ -1,5 +1,7 @@
+[general]
+auth_token_type = Bearer
+
 [retry_settings]
 max_retries = 3
 retry_delay = 5
 http_timeout = 5
-

--- a/agents/config.ini
+++ b/agents/config.ini
@@ -1,3 +1,5 @@
 [retry_settings]
 max_retries = 3
 retry_delay = 5
+http_timeout = 5
+

--- a/agents/dns/dns.py
+++ b/agents/dns/dns.py
@@ -1,5 +1,5 @@
 from ..agent import ServerAgent
-
+import json
 
 class DNSAgent(ServerAgent):
 
@@ -18,3 +18,25 @@ class DNSAgent(ServerAgent):
             interface=interface,
             controller_url=controller_url,
         )
+
+if __name__ == '__main__':
+    try:
+        agent = DNSAgent()
+
+        agent.collect_server_metadata()
+
+        data = agent.status_to_dict()
+        print(json.dumps(data, indent=2))
+
+        agent.controller_url = 'http://192.168.64.1:8000/api/v1/server/status/'
+
+        if agent.controller_url:
+            post_result = agent.post_data(agent.controller_url, data)
+            print('Post result:', post_result)
+            print('Status to controller: ', agent.status_to_controller())
+        else:
+            print('No controller URL specified, skipping POST request.')
+
+    except Exception as e:
+        print('Error: {0}'.format(str(e)))
+

--- a/agents/dns/dns.py
+++ b/agents/dns/dns.py
@@ -1,5 +1,5 @@
 from ..agent import ServerAgent
-import json
+
 
 class DNSAgent(ServerAgent):
 
@@ -18,25 +18,3 @@ class DNSAgent(ServerAgent):
             interface=interface,
             controller_url=controller_url,
         )
-
-if __name__ == '__main__':
-    try:
-        agent = DNSAgent()
-
-        agent.collect_server_metadata()
-
-        data = agent.status_to_dict()
-        print(json.dumps(data, indent=2))
-
-        agent.controller_url = 'http://192.168.64.1:8000/api/v1/server/status/'
-
-        if agent.controller_url:
-            post_result = agent.post_data(agent.controller_url, data)
-            print('Post result:', post_result)
-            print('Status to controller: ', agent.status_to_controller())
-        else:
-            print('No controller URL specified, skipping POST request.')
-
-    except Exception as e:
-        print('Error: {0}'.format(str(e)))
-

--- a/agents/tests/test_agent.py
+++ b/agents/tests/test_agent.py
@@ -211,3 +211,86 @@ def test_status_to_controller_http_error():
     assert msg in contents, (
         'Expected %s in logs, got:\n%s' % (msg, contents)
     )
+
+
+def test_post_data_success(monkeypatch):
+    agent = MockAgent(port=12345)
+    agent.setup_logging()
+
+    class MockResponse:
+        def getcode(self):
+            return 200
+
+        def read(self):
+            return b'Success'
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(urllib2, 'urlopen', lambda req: MockResponse())
+
+    result = agent.post_data('http://mock/api', {'test': 'data'})
+
+    with open(agent.logfile.name) as f:
+        contents = f.read()
+
+    assert result == b'Success'
+    assert 'POST request status: 200' in contents
+    assert 'Success on attempt 1' in contents
+
+
+def test_post_data_retry(monkeypatch):
+    agent = MockAgent(port=12345)
+    agent.setup_logging()
+
+    call_count = {'count': 0}
+
+    def mock_urlopen(req):
+        call_count['count'] += 1
+        if call_count['count'] < 2:
+            raise urllib2.URLError('Temporary failure')
+        class MockResponse:
+            def getcode(self):
+                return 200
+            def read(self):
+                return b'Retry Success'
+            def close(self):
+                pass
+        return MockResponse()
+
+    monkeypatch.setattr(urllib2, 'urlopen', mock_urlopen)
+
+    result = agent.post_data(
+        'http://mock/api', {'retry': 'test'}, max_retries=3, delay=0
+    )
+
+    with open(agent.logfile.name) as f:
+        contents = f.read()
+
+    assert call_count['count'] == 2
+    assert result == b'Retry Success'
+    assert 'Retrying in 0 seconds...' in contents
+    assert 'Success on attempt 2' in contents
+
+
+def test_post_data_max_retries_fail(monkeypatch):
+    agent = MockAgent(port=12345)
+    agent.setup_logging()
+
+    monkeypatch.setattr(
+        urllib2,
+        'urlopen',
+        lambda req: (_ for _ in ()).throw(urllib2.URLError('Permanent error'))
+    )
+
+    with pytest.raises(RuntimeError, match='POST failed after 3 attempts'):
+        agent.post_data(
+            'http://mock/api', {'fail': True}, max_retries=3, delay=0
+        )
+
+    with open(agent.logfile.name) as f:
+        contents = f.read()
+
+    assert 'All 3 attempts failed. Data not sent.' in contents
+    assert 'Permanent error' in contents
+

--- a/agents/tests/test_agent.py
+++ b/agents/tests/test_agent.py
@@ -227,7 +227,9 @@ def test_post_data_success(monkeypatch):
         def close(self):
             pass
 
-    monkeypatch.setattr(urllib2, 'urlopen', lambda req, timeout=None: MockResponse())
+    monkeypatch.setattr(
+        urllib2, 'urlopen', lambda req, timeout=None: MockResponse()
+    )
 
     result = agent.post_data('http://mock/api', {'test': 'data'})
 
@@ -249,13 +251,18 @@ def test_post_data_retry(monkeypatch):
         call_count['count'] += 1
         if call_count['count'] < 2:
             raise urllib2.URLError('Temporary failure')
+
         class MockResponse:
+
             def getcode(self):
                 return 200
+
             def read(self):
                 return b'Retry Success'
+
             def close(self):
                 pass
+
         return MockResponse()
 
     monkeypatch.setattr(urllib2, 'urlopen', mock_urlopen)
@@ -280,7 +287,9 @@ def test_post_data_max_retries_fail(monkeypatch):
     monkeypatch.setattr(
         urllib2,
         'urlopen',
-        lambda req, timeout=None: (_ for _ in ()).throw(urllib2.URLError('Permanent error'))
+        lambda req, timeout=None: (
+            _ for _ in ()
+        ).throw(urllib2.URLError('Permanent error'))
     )
 
     with pytest.raises(RuntimeError, match='POST failed after 3 attempts'):
@@ -293,4 +302,3 @@ def test_post_data_max_retries_fail(monkeypatch):
 
     assert 'All 3 attempts failed. Data not sent.' in contents
     assert 'Permanent error' in contents
-

--- a/agents/tests/test_agent.py
+++ b/agents/tests/test_agent.py
@@ -227,7 +227,7 @@ def test_post_data_success(monkeypatch):
         def close(self):
             pass
 
-    monkeypatch.setattr(urllib2, 'urlopen', lambda req: MockResponse())
+    monkeypatch.setattr(urllib2, 'urlopen', lambda req, timeout=None: MockResponse())
 
     result = agent.post_data('http://mock/api', {'test': 'data'})
 
@@ -245,7 +245,7 @@ def test_post_data_retry(monkeypatch):
 
     call_count = {'count': 0}
 
-    def mock_urlopen(req):
+    def mock_urlopen(req, timeout=None):
         call_count['count'] += 1
         if call_count['count'] < 2:
             raise urllib2.URLError('Temporary failure')
@@ -280,7 +280,7 @@ def test_post_data_max_retries_fail(monkeypatch):
     monkeypatch.setattr(
         urllib2,
         'urlopen',
-        lambda req: (_ for _ in ()).throw(urllib2.URLError('Permanent error'))
+        lambda req, timeout=None: (_ for _ in ()).throw(urllib2.URLError('Permanent error'))
     )
 
     with pytest.raises(RuntimeError, match='POST failed after 3 attempts'):

--- a/agents/tests/test_agent.py
+++ b/agents/tests/test_agent.py
@@ -107,6 +107,12 @@ def test_status_to_controller_success():
             def getcode(self):
                 return 201
 
+            def read(self):
+                return b'{"message":"status received"}'
+
+            def close(self):
+                pass
+
         return MockResponse()
 
     agent = MockAgent(port=12345)


### PR DESCRIPTION
Closes #9 
Description:
Enhance the agent.py script with error handling to make it more robust. If the HTTP POST request to the Django controller fails (e.g., due to connection issues or server downtime), the agent should automatically retry sending the data up to 3 times with short delays. All attempts and failures should be logged in the local log file.

✅ Ready to review