### PR TITLE
99 improve logging setup in agents

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+omit =
+    */migrations/*
+    agents/dev/*

--- a/.github/workflows/agents-tests-on-pull-request.yaml
+++ b/.github/workflows/agents-tests-on-pull-request.yaml
@@ -48,10 +48,10 @@ jobs:
           -v "$PWD":/pydata \
           python:2.7 \
           bash -c "
-            cd /pydata/agents && \
-            pip install -r requirements.txt && \
+            cd /pydata && \
+            pip install -r agents/requirements.txt && \
             pip install pytest pytest-cov==2.4.0 && \
-            python -m pytest --cov=. --cov-report=xml:/pydata/coverage.xml
+            python -m pytest agents --cov=agents --cov-config=.coveragerc --cov-report=xml:/pydata/agents/coverage.xml
           "
 
       - name: Upload Coverage Report to Codecov

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <a href="https://softserve.academy/"><img src="https://s.057.ua/section/newsInternalIcon/upload/images/news/icon/000/050/792/vnutr_5ce4f980ef15f.jpg" title="SoftServe IT Academy" alt="SoftServe IT Academy"></a>
 
 [![agents tests](https://github.com/ITA-Dnipro/PyDataCenter5000/actions/workflows/agents-tests-on-pull-request.yaml/badge.svg)](https://github.com/ITA-Dnipro/PyDataCenter5000/actions/workflows/agents-tests-on-pull-request.yaml)
-[![agents test coverage](https://codecov.io/github/ITA-Dnipro/PyDataCenter5000/branch/develop/graph/badge.svg?token=IYV4B8RAZE)](https://codecov.io/github/ITA-Dnipro/PyDataCenter5000)
+[![agents test coverage](https://codecov.io/github/ITA-Dnipro/PyDataCenter5000/branch/develop/graph/badge.svg?token=IYV4B8RAZE&label=agents)](https://codecov.io/github/ITA-Dnipro/PyDataCenter5000)
 
 # PyDataCenter5000
 > PyDataCenter: Smart Monitoring and Remote Ops
@@ -52,28 +52,6 @@ Develop a system that simulates a mini data center using VirtualBox. Each virtua
 * `controller/` — Central monitoring station (GUI or CLI)
 * `docs/` — Installation and configuration documentation
 * `vagrant/` — Scripts for setting up the infrastructure
-
----
-
-**Badges will go here**
-
-- build status
-- coverage
-- issues (waffle.io maybe)
-- devDependencies
-- npm package
-- slack
-- downloads
-- gitter chat
-- license
-- etc.
-
-[![Coverage Status](https://img.shields.io/gitlab/coverage/ita-social-projects/Forum/master?style=flat-square)](https://coveralls.io)
-[![Github Issues](https://img.shields.io/github/issues/ita-social-projects/Forum?style=flat-square)](https://github.com/ita-social-projects/Forum/issues)
-[![Pending Pull-Requests](https://img.shields.io/github/issues-pr/ita-social-projects/Forum?style=flat-square)](https://github.com/ita-social-projects/Forum/pulls)
-[![License](http://img.shields.io/:license-mit-blue.svg?style=flat-square)](http://badges.mit-license.org)
-
----
 
 ## Table of Contents (Optional)
 

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -77,6 +77,7 @@ class ServerAgent(object):
         processes=None,
         interface=None,
         controller_url=None,
+        log_path=None,
     ):
         self.server_name = server_name
         self.port = port if port is not None else self.port
@@ -89,6 +90,20 @@ class ServerAgent(object):
         # to user that collect_server_metadata hasn't been called.
         self.os_type = self.hostname = self.ip = None
         self.uptime = self.timestamp = None
+
+        # Initialize logging from logging config file
+        log_path = (
+            log_path or pkg_resources.
+            resource_filename(self.__class__.__module__, 'logs/agent.log')
+        )
+
+        logging.config.fileConfig(
+            log_config_path,
+            defaults={
+                'agent_name': self.server_name,
+                'log_path': log_path
+            },
+        )
 
     @classmethod
     def from_config_file(cls, filename=None, log_path=None):
@@ -105,10 +120,19 @@ class ServerAgent(object):
         """
         agent = cls()
 
-        agent.setup_logging(path=log_path)
         agent._parse_config_file(filename)
 
         return agent
+
+    @property
+    def logger(self):
+        return logging.getLogger(self.server_name)
+
+    @property
+    def fallback_logger(self):
+        logging.getLogger(
+            '_'.join([self.server_name, 'fallback'])
+        )
 
     @property
     def port(self):
@@ -134,26 +158,6 @@ class ServerAgent(object):
                 )
             )
         self._processes = value
-
-    def setup_logging(self, path=None):
-        # Have each child dump logs inside their own subpackage by default
-        path = (
-            path or pkg_resources.
-            resource_filename(self.__class__.__module__, 'logs/agent.log')
-        )
-
-        logging.config.fileConfig(
-            log_config_path,
-            defaults={
-                'agent_name': self.server_name,
-                'log_path': path
-            },
-        )
-
-        self.logger = logging.getLogger(self.server_name)
-        self.fallback_logger = logging.getLogger(
-            '_'.join([self.server_name, 'fallback'])
-        )
 
     def _parse_config_file(self, filename=None):
         """Parse server's config file using ConfigParser."""

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -130,7 +130,7 @@ class ServerAgent(object):
 
     @property
     def fallback_logger(self):
-        logging.getLogger(
+        return logging.getLogger(
             '_'.join([self.server_name, 'fallback'])
         )
 

--- a/agents/dns/dns.py
+++ b/agents/dns/dns.py
@@ -10,6 +10,7 @@ class DNSAgent(ServerAgent):
         processes=None,
         interface=None,
         controller_url=None,
+        log_path=None,
     ):
         super(DNSAgent, self).__init__(
             server_name=server_name,
@@ -17,4 +18,5 @@ class DNSAgent(ServerAgent):
             processes=processes or ['named', 'bind9'],
             interface=interface,
             controller_url=controller_url,
+            log_path=log_path,
         )

--- a/agents/smtp/smtp.py
+++ b/agents/smtp/smtp.py
@@ -12,6 +12,7 @@ class SMTPAgent(ServerAgent):
         processes=None,
         interface=None,
         controller_url=None,
+        log_path=None,
     ):
         super(SMTPAgent, self).__init__(
             server_name=server_name,
@@ -19,4 +20,5 @@ class SMTPAgent(ServerAgent):
             processes=processes or ['postfix', 'exim', 'sendmail', 'master'],
             interface=interface,
             controller_url=controller_url,
+            log_path=log_path,
         )

--- a/agents/tests/test_agent.py
+++ b/agents/tests/test_agent.py
@@ -17,25 +17,25 @@ class MockAgent(ServerAgent):
         server_name='mock',
         port=None,
         processes=None,
+        interface=None,
         controller_url=None,
-        config_file=None,
+        log_path=None,
     ):
+        self.logfile = tempfile.NamedTemporaryFile(delete=False)
+        self.logfile.close()
+
         super(MockAgent, self).__init__(
-            server_name, port, processes, controller_url, config_file
+            server_name,
+            port,
+            processes,
+            interface,
+            controller_url,
+            log_path or self.logfile.name,
         )
 
-    def setup_logging(self, path=None):
-        if not path:
-            self.logfile = tempfile.NamedTemporaryFile(delete=False)
-            self.logfile.close()
-
-            path = self.logfile.name
-
-        return super(MockAgent, self).setup_logging(path)
-
     def __del__(self):
-        if self.log_path:
-            os.remove(self.log_path)
+        if self.logfile:
+            os.remove(self.logfile)
 
 
 def test_type_checks_on_init():
@@ -76,7 +76,6 @@ def test_status_to_json_type_error():
         return status
 
     agent = MockAgent(port=12345)
-    agent.setup_logging()
 
     agent.status_to_dict = types.MethodType(mock_status_to_dict, agent)
 
@@ -116,7 +115,6 @@ def test_status_to_controller_success():
         return MockResponse()
 
     agent = MockAgent(port=12345)
-    agent.setup_logging()
 
     agent.collect_server_metadata()
 
@@ -137,7 +135,6 @@ def test_status_to_controller_success():
 def test_status_to_controller_missing_url():
     """Test that missing controller URL is properly handled and logged."""
     agent = MockAgent(port=12345)
-    agent.setup_logging()
     agent.collect_server_metadata()
 
     # Set controller's URL explicitly to be independent of changes
@@ -195,7 +192,6 @@ def test_status_to_controller_http_error():
             raise error
 
     agent = MockAgent(port=12345)
-    agent.setup_logging()
 
     agent.collect_server_metadata()
 
@@ -215,7 +211,6 @@ def test_status_to_controller_http_error():
 
 def test_post_data_success(monkeypatch):
     agent = MockAgent(port=12345)
-    agent.setup_logging()
 
     class MockResponse:
         def getcode(self):
@@ -243,7 +238,6 @@ def test_post_data_success(monkeypatch):
 
 def test_post_data_retry(monkeypatch):
     agent = MockAgent(port=12345)
-    agent.setup_logging()
 
     call_count = {'count': 0}
 
@@ -282,7 +276,6 @@ def test_post_data_retry(monkeypatch):
 
 def test_post_data_max_retries_fail(monkeypatch):
     agent = MockAgent(port=12345)
-    agent.setup_logging()
 
     monkeypatch.setattr(
         urllib2,

--- a/agents/tests/test_web_agent.py
+++ b/agents/tests/test_web_agent.py
@@ -1,8 +1,10 @@
+import logging
 import os
 import tempfile
+from logging.handlers import MemoryHandler
 
 import pytest
-from mock import MagicMock, patch
+from mock import patch
 
 from agents.web.web import WebAgent
 
@@ -15,10 +17,13 @@ def web_agent():
     logfile = tempfile.NamedTemporaryFile(delete=False)
     logfile.close()
 
-    agent = WebAgent()
-    agent.setup_logging(logfile.name)
+    agent = WebAgent(log_path=logfile.name)
 
-    yield agent
+    handler = MemoryHandler(capacity=10000)
+    agent.logger.addHandler(handler)
+    agent.logger.setLevel(logging.INFO)
+
+    yield agent, handler
 
     if os.path.exists(logfile.name):
         os.remove(logfile.name)
@@ -26,6 +31,8 @@ def web_agent():
 
 def test_to_dict_format(web_agent):
     """Test that to_dict returns a dictionary with correct key-value types"""
+    web_agent, _ = web_agent
+
     web_agent.collect_server_metadata()  # Initialize metadata
     result = web_agent.status_to_dict()
 
@@ -50,6 +57,8 @@ def test_to_dict_format(web_agent):
 
 def test_to_dict_timestamp_format(web_agent):
     """Test that timestamp in to_dict follows the correct format"""
+    web_agent, _ = web_agent
+
     web_agent.collect_server_metadata()  # Initialize metadata
     result = web_agent.status_to_dict()
     timestamp = result['timestamp']
@@ -64,6 +73,8 @@ def test_to_dict_timestamp_format(web_agent):
 @patch('agents.web.web.WebAgent.service_healthy')
 def test_to_dict_healthy_status(mock_healthy, web_agent):
     """Test that healthy status is correctly reflected in to_dict"""
+    web_agent, _ = web_agent
+
     # Test when service is healthy
     mock_healthy.return_value = True
     result = web_agent.status_to_dict()
@@ -77,14 +88,12 @@ def test_to_dict_healthy_status(mock_healthy, web_agent):
 
 def test_to_txt(web_agent):
     """Test that to_txt logs each key-value pair"""
-    # Create a mock logger
-    mock_logger = MagicMock()
-    web_agent.logger = mock_logger
+    web_agent, handler = web_agent
 
     web_agent.status_to_txt()
 
     # Get all logged messages
-    logged_messages = [call[0][0] for call in mock_logger.info.call_args_list]
+    logged_messages = [record.getMessage() for record in handler.buffer]
 
     # Check that each key-value pair from to_dict is logged
     dict_data = web_agent.status_to_dict()

--- a/agents/web/web.py
+++ b/agents/web/web.py
@@ -12,6 +12,7 @@ class WebAgent(ServerAgent):
         processes=None,
         interface=None,
         controller_url=None,
+        log_path=None,
     ):
         if port is None and 'PORT' not in os.environ:
             raise ValueError('WEB port environment variable is not set.')
@@ -24,4 +25,5 @@ class WebAgent(ServerAgent):
             processes=processes or ['uvicorn'],
             interface=interface,
             controller_url=controller_url,
+            log_path=log_path,
         )


### PR DESCRIPTION
This small PR fixes an issue that without manual setup of logging, an `AttributeError` would occur. Logging config file is now processed upon instantiation. Calls to `agent.logger` and `agent.fallback_logger`, are implemented via properties, which exploit the fact that `logging.getLogger(<name>)` has singleton-like behavior.