### PR TITLE
89 - Store Extended Metrics in the Backend

### DIFF
--- a/pydata_center/monitoring/admin.py
+++ b/pydata_center/monitoring/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from .models import CommandHistory, ServerStatus
+from .models import AgentMetric, CommandHistory, ServerStatus
 
 
 @admin.register(CommandHistory)
@@ -18,3 +18,14 @@ class ServerStatusAdmin(admin.ModelAdmin):
     list_filter = ('server_name', )
     readonly_fields = ('hostname', 'ip', 'uptime', 'server_name', 'timestamp')
     ordering = ('-timestamp', )
+
+
+@admin.register(AgentMetric)
+class AgentMetricAdmin(admin.ModelAdmin):
+    list_display = (
+        'server_status', 'timestamp', 'cpu', 'ram', 'disk', 'load_avg'
+    )
+    search_fields = ('server_status__hostname', 'server_status__server_name')
+    list_filter = ('server_status__server_name', )
+    ordering = ('-timestamp', )
+    readonly_fields = ('timestamp', )

--- a/pydata_center/monitoring/migrations/0005_alter_commandhistory_hostname_and_more.py
+++ b/pydata_center/monitoring/migrations/0005_alter_commandhistory_hostname_and_more.py
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
             name='hostname',
             field=models.CharField(
                 db_index=True,
-                max_length=100,
+                max_length=100
             ),
         ),
         migrations.AlterField(
@@ -22,7 +22,7 @@ class Migration(migrations.Migration):
             name='result',
             field=models.TextField(
                 blank=True,
-                null=True,
+                null=True
             ),
         ),
         migrations.AlterField(
@@ -36,14 +36,7 @@ class Migration(migrations.Migration):
                 ],
                 db_index=True,
                 default='pending',
-                max_length=10,
-            ),
-        ),
-        migrations.AlterField(
-            model_name='serverstatus',
-            name='timestamp',
-            field=models.DateTimeField(
-                auto_now_add=True,
+                max_length=10
             ),
         ),
         migrations.CreateModel(
@@ -55,23 +48,49 @@ class Migration(migrations.Migration):
                         auto_created=True,
                         primary_key=True,
                         serialize=False,
-                        verbose_name='ID',
+                        verbose_name='ID'
                     )
                 ),
-                ('cpu', models.FloatField(blank=True, null=True)),
-                ('ram', models.FloatField(blank=True, null=True)),
-                ('disk', models.FloatField(blank=True, null=True)),
-                ('load_avg', models.FloatField(blank=True, null=True)),
+                (
+                    'cpu',
+                    models.FloatField(
+                        blank=True,
+                        null=True
+                    )
+                ),
+                (
+                    'ram',
+                    models.FloatField(
+                        blank=True,
+                        null=True
+                    )
+                ),
+                (
+                    'disk',
+                    models.FloatField(
+                        blank=True,
+                        null=True
+                    )
+                ),
+                (
+                    'load_avg',
+                    models.FloatField(
+                        blank=True,
+                        null=True
+                    )
+                ),
                 (
                     'timestamp',
-                    models.DateTimeField(auto_now_add=True),
+                    models.DateTimeField(
+                        auto_now_add=True
+                    )
                 ),
                 (
                     'server_status',
                     models.ForeignKey(
                         on_delete=django.db.models.deletion.CASCADE,
                         related_name='server_status',
-                        to='monitoring.serverstatus',
+                        to='monitoring.serverstatus'
                     )
                 ),
             ],
@@ -79,7 +98,7 @@ class Migration(migrations.Migration):
                 'indexes': [
                     models.Index(
                         fields=['server_status', 'timestamp'],
-                        name='monitoring__server__0620a3_idx',
+                        name='monitoring__server__0620a3_idx'
                     ),
                 ],
             },

--- a/pydata_center/monitoring/migrations/0005_alter_commandhistory_hostname_and_more.py
+++ b/pydata_center/monitoring/migrations/0005_alter_commandhistory_hostname_and_more.py
@@ -12,12 +12,18 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='commandhistory',
             name='hostname',
-            field=models.CharField(db_index=True, max_length=100),
+            field=models.CharField(
+                db_index=True,
+                max_length=100,
+            ),
         ),
         migrations.AlterField(
             model_name='commandhistory',
             name='result',
-            field=models.TextField(blank=True, null=True),
+            field=models.TextField(
+                blank=True,
+                null=True,
+            ),
         ),
         migrations.AlterField(
             model_name='commandhistory',
@@ -30,38 +36,51 @@ class Migration(migrations.Migration):
                 ],
                 db_index=True,
                 default='pending',
-                max_length=10
+                max_length=10,
             ),
         ),
         migrations.AlterField(
             model_name='serverstatus',
             name='timestamp',
-            field=models.DateTimeField(auto_now_add=True),
+            field=models.DateTimeField(
+                auto_now_add=True,
+            ),
         ),
         migrations.CreateModel(
             name='AgentMetric',
             fields=[
-                ('id', models.BigAutoField(
-                    auto_created=True,
-                    primary_key=True,
-                    serialize=False,
-                    verbose_name='ID')
-                 ),
+                (
+                    'id',
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name='ID',
+                    )
+                ),
                 ('cpu', models.FloatField(blank=True, null=True)),
                 ('ram', models.FloatField(blank=True, null=True)),
                 ('disk', models.FloatField(blank=True, null=True)),
                 ('load_avg', models.FloatField(blank=True, null=True)),
-                ('timestamp', models.DateTimeField(auto_now_add=True)),
-                ('server_status', models.ForeignKey(
-                    on_delete=django.db.models.deletion.CASCADE,
-                    related_name='server_status',
-                    to='monitoring.serverstatus')
-                 ),
+                (
+                    'timestamp',
+                    models.DateTimeField(auto_now_add=True),
+                ),
+                (
+                    'server_status',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='server_status',
+                        to='monitoring.serverstatus',
+                    )
+                ),
             ],
             options={
                 'indexes': [
-                    models.Index(fields=['server_status', 'timestamp'],
-                                 name='monitoring__server__0620a3_idx')
+                    models.Index(
+                        fields=['server_status', 'timestamp'],
+                        name='monitoring__server__0620a3_idx',
+                    ),
                 ],
             },
         ),

--- a/pydata_center/monitoring/migrations/0005_alter_commandhistory_hostname_and_more.py
+++ b/pydata_center/monitoring/migrations/0005_alter_commandhistory_hostname_and_more.py
@@ -1,0 +1,68 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('monitoring', '0004_commandhistory'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='commandhistory',
+            name='hostname',
+            field=models.CharField(db_index=True, max_length=100),
+        ),
+        migrations.AlterField(
+            model_name='commandhistory',
+            name='result',
+            field=models.TextField(blank=True, null=True),
+        ),
+        migrations.AlterField(
+            model_name='commandhistory',
+            name='status',
+            field=models.CharField(
+                choices=[
+                    ('pending', 'Pending'),
+                    ('done', 'Done'),
+                    ('failed', 'Failed')
+                ],
+                db_index=True,
+                default='pending',
+                max_length=10
+            ),
+        ),
+        migrations.AlterField(
+            model_name='serverstatus',
+            name='timestamp',
+            field=models.DateTimeField(auto_now_add=True),
+        ),
+        migrations.CreateModel(
+            name='AgentMetric',
+            fields=[
+                ('id', models.BigAutoField(
+                    auto_created=True,
+                    primary_key=True,
+                    serialize=False,
+                    verbose_name='ID')
+                 ),
+                ('cpu', models.FloatField(blank=True, null=True)),
+                ('ram', models.FloatField(blank=True, null=True)),
+                ('disk', models.FloatField(blank=True, null=True)),
+                ('load_avg', models.FloatField(blank=True, null=True)),
+                ('timestamp', models.DateTimeField(auto_now_add=True)),
+                ('server_status', models.ForeignKey(
+                    on_delete=django.db.models.deletion.CASCADE,
+                    related_name='server_status',
+                    to='monitoring.serverstatus')
+                 ),
+            ],
+            options={
+                'indexes': [
+                    models.Index(fields=['server_status', 'timestamp'],
+                                 name='monitoring__server__0620a3_idx')
+                ],
+            },
+        ),
+    ]

--- a/pydata_center/monitoring/models.py
+++ b/pydata_center/monitoring/models.py
@@ -11,7 +11,7 @@ class ServerStatus(models.Model):
     hostname = models.CharField(max_length=100)
     ip = models.GenericIPAddressField()
     uptime = models.FloatField()
-    timestamp = models.DateTimeField(auto_now_add=True)
+    timestamp = models.DateTimeField()
     os = models.CharField(max_length=50)
     healthy = models.BooleanField(default=False)
     server_name = models.CharField(max_length=50)

--- a/pydata_center/monitoring/models.py
+++ b/pydata_center/monitoring/models.py
@@ -11,7 +11,7 @@ class ServerStatus(models.Model):
     hostname = models.CharField(max_length=100)
     ip = models.GenericIPAddressField()
     uptime = models.FloatField()
-    timestamp = models.DateTimeField()
+    timestamp = models.DateTimeField(auto_now_add=True)
     os = models.CharField(max_length=50)
     healthy = models.BooleanField(default=False)
     server_name = models.CharField(max_length=50)
@@ -19,6 +19,26 @@ class ServerStatus(models.Model):
 
     def __str__(self):
         return f'{self.hostname} - {self.timestamp}'
+
+
+class AgentMetric(models.Model):
+    cpu = models.FloatField(null=True, blank=True)
+    ram = models.FloatField(null=True, blank=True)
+    disk = models.FloatField(null=True, blank=True)
+    load_avg = models.FloatField(null=True, blank=True)
+    timestamp = models.DateTimeField(auto_now_add=True)
+
+    server_status = models.ForeignKey(
+        ServerStatus, on_delete=models.CASCADE, related_name='server_status'
+    )
+
+    class Meta:
+        indexes = [
+            models.Index(fields=['server_status', 'timestamp']),
+        ]
+
+    def __str__(self):
+        return f'Metrics for {self.server_status.hostname} at {self.timestamp}'
 
 
 class CommandHistory(models.Model):

--- a/pydata_center/monitoring/serializers.py
+++ b/pydata_center/monitoring/serializers.py
@@ -1,9 +1,46 @@
 from rest_framework import serializers
 
-from .models import CommandHistory, ServerStatus
+from .models import AgentMetric, CommandHistory, ServerStatus
+
+
+class AgentMetricSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = AgentMetric
+        fields = (
+            'id',
+            'timestamp',
+            'cpu',
+            'ram',
+            'disk',
+            'load_avg',
+            'server_status',
+        )
+        read_only_fields = ('id', 'timestamp')
+
+    def validate_cpu(self, value):
+        if value is not None and not (0 <= value <= 100):
+            raise serializers.ValidationError('CPU usage must be 0–100%.')
+        return value
+
+    def validate_ram(self, value):
+        if value is not None and not (0 <= value <= 100):
+            raise serializers.ValidationError('RAM usage must be 0–100%.')
+        return value
+
+    def validate_disk(self, value):
+        if value is not None and not (0 <= value <= 100):
+            raise serializers.ValidationError('Disk usage must be 0–100%.')
+        return value
+
+    def validate_load_avg(self, value):
+        if value is not None and value < 0:
+            raise serializers.ValidationError('Load average must be ≥ 0.')
+        return value
 
 
 class ServerStatusSerializer(serializers.ModelSerializer):
+    metrics = AgentMetricSerializer(many=True, read_only=True)
+
     class Meta:
         model = ServerStatus
         fields = '__all__'


### PR DESCRIPTION
Closes #89 
- [x] create AgentMetric model for storing new resource usage data (CPU, RAM, disk, load average) reported by agents
- [x] run migrations
- [x] add it to admin panel
- [x] serializers update
- [x] log any dropped or malformed metric values - logs every time validation error occurs

✅ ready for review