### PR TITLE
112 fix agents not finding processes if searched for name is a composite of an actual name

### DIFF
--- a/agents/agent.py
+++ b/agents/agent.py
@@ -405,7 +405,10 @@ class ServerAgent(object):
 
             output = output.lower()
 
-            return any(proc in output.split() for proc in self.processes)
+            return any(
+                any(proc in p for p in output.split())
+                for proc in self.processes
+            )
         except OSError as e:
             maybe_log_message(
                 'Process check failed: %s' % e,

--- a/agents/smtp/smtp.py
+++ b/agents/smtp/smtp.py
@@ -54,7 +54,7 @@ class SMTPAgent(ServerAgent):
 
     def service_healthy(self):
         status = super(SMTPAgent, self).service_healthy()
-        return status and self.check_banner()
+        return status and bool(self.check_banner())
 
     def status_to_dict(self):
         status = super(SMTPAgent, self).status_to_dict()


### PR DESCRIPTION
This PR contains two fixes to have agents evaluate health status correctly:

- If the name of a server-specific process specified in config appears as a substring of a process displayed by `ps -eo comm`, the agent shouldn't ignore it. Example: Active Sendmail process displays as `sendmail-mta` on Ubuntu.
- SMTP agent was returning the SMTP banner instead of a boolean on health check - this is just a bug. 