### PR TITLE
fix: have from_config_file instantiate agent with custom log_path properly

### DIFF
--- a/agents/agent.py
+++ b/agents/agent.py
@@ -147,7 +147,7 @@ class ServerAgent(object):
         Returns:
             ServerAgent: Child instance of ServerAgent.
         """
-        agent = cls()
+        agent = cls(log_path=log_path)
 
         agent._parse_config_file(filename)
 


### PR DESCRIPTION
This PR fixes bug where the factory method `from_config_file` was accepting custom logging path as a parameter, but never passing it to the constructor - the agent would always log to the default path.