### PR TITLE
Add full API documentation using drf-spectacular + Swagger & ReDoc UI

### DIFF
--- a/pydata_center/monitoring/views.py
+++ b/pydata_center/monitoring/views.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 
 
 @extend_schema(
+        tags=['Server Status'],
         request=ServerStatusSerializer,
         responses={
             status.HTTP_201_CREATED: OpenApiResponse(
@@ -88,10 +89,12 @@ def receive_status(request):
             ),
         ],
         responses=CommandHistorySerializer(many=True),
+        tags=['Command'],
     ),
     retrieve=extend_schema(
         description='Get a specific command record by ID.',
         responses=CommandHistorySerializer,
+        tags=['Command'],
     ),
     create=extend_schema(
         description=(
@@ -99,13 +102,16 @@ def receive_status(request):
             'Status will be set to \'pending\' by default.'
         ),
         responses=CommandHistorySerializer,
+        tags=['Command'],
     ),
     partial_update=extend_schema(
         description='Update command status or result (partial).',
         responses=CommandHistorySerializer,
+        tags=['Command'],
     ),
     destroy=extend_schema(
         description='Delete command record by ID.',
+        tags=['Command'],
     ),
 )
 class CommandHistoryViewSet(viewsets.ModelViewSet):
@@ -149,6 +155,7 @@ class CommandHistoryViewSet(viewsets.ModelViewSet):
 
 
 @extend_schema(
+    tags=['Command'],
     description='Agent fetches a pending command by providing its hostname.',
     parameters=[
         OpenApiParameter(
@@ -198,6 +205,7 @@ def fetch_pending_command(request):
 
 
 @extend_schema(
+        tags=['Command'],
         request=CommandHistorySerializer,
         responses={
             status.HTTP_200_OK: CommandHistorySerializer,

--- a/pydata_center/monitoring/views.py
+++ b/pydata_center/monitoring/views.py
@@ -20,9 +20,15 @@ logger = logging.getLogger(__name__)
 @extend_schema(
         request=ServerStatusSerializer,
         responses={
-            201: OpenApiResponse(description='Status received and logged.'),
-            400: OpenApiResponse(description='Invalid data.'),
-            500: OpenApiResponse(description='Internal server error.')
+            status.HTTP_201_CREATED: OpenApiResponse(
+                description='Status received and logged.'
+            ),
+            status.HTTP_400_BAD_REQUEST: OpenApiResponse(
+                description='Invalid data.'
+            ),
+            status.HTTP_500_INTERNAL_SERVER_ERROR: OpenApiResponse(
+                description='Internal server error.'
+            ),
         },
         description='Receive and log server status data sent via POST request.'
 )
@@ -158,9 +164,13 @@ class CommandHistoryViewSet(viewsets.ModelViewSet):
         )
     ],
     responses={
-        200: CommandHistorySerializer,
-        204: OpenApiResponse(description='No pending commands'),
-        400: OpenApiResponse(description='Hostname is required')
+        status.HTTP_200_OK: CommandHistorySerializer,
+        status.HTTP_204_NO_CONTENT: OpenApiResponse(
+            description='No pending commands'
+        ),
+        status.HTTP_400_BAD_REQUEST: OpenApiResponse(
+            description='Hostname is required'
+        ),
     }
 )
 @api_view(['GET'])
@@ -194,11 +204,13 @@ def fetch_pending_command(request):
 @extend_schema(
         request=CommandHistorySerializer,
         responses={
-            200: CommandHistorySerializer,
-            400: OpenApiResponse(
+            status.HTTP_200_OK: CommandHistorySerializer,
+            status.HTTP_400_BAD_REQUEST: OpenApiResponse(
                 description='Validation error or invalid status'
             ),
-            404: OpenApiResponse(description='Command not found or ID missing')
+            status.HTTP_404_NOT_FOUND: OpenApiResponse(
+                description='Command not found or ID missing'
+            ),
         },
         description=(
             'Agent submits the result or status update for a command by ID.'

--- a/pydata_center/monitoring/views.py
+++ b/pydata_center/monitoring/views.py
@@ -2,6 +2,9 @@ import logging
 
 from django.shortcuts import render
 from django.utils.timezone import now
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import (OpenApiParameter, OpenApiResponse,
+                                   extend_schema, extend_schema_view)
 from rest_framework import filters, status, viewsets
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
@@ -14,6 +17,15 @@ from .utils import extract_status_data, get_client_ip
 logger = logging.getLogger(__name__)
 
 
+@extend_schema(
+        request=ServerStatusSerializer,
+        responses={
+            201: OpenApiResponse(description='Status received and logged.'),
+            400: OpenApiResponse(description='Invalid data.'),
+            500: OpenApiResponse(description='Internal server error.')
+        },
+        description='Receive and log server status data sent via POST request.'
+)
 @api_view(['POST'])
 def receive_status(request):
     """
@@ -55,6 +67,45 @@ def receive_status(request):
         )
 
 
+@extend_schema_view(
+    list=extend_schema(
+        description=(
+            'List of all command records.'
+            'Supports filtering by hostname and status.'
+        ),
+        parameters=[
+            OpenApiParameter(
+                name='hostname',
+                type=str, location=OpenApiParameter.QUERY,
+                description='Filter by agent hostname'
+            ),
+            OpenApiParameter(
+                name='status', type=str,
+                location=OpenApiParameter.QUERY,
+                description='Filter by command status'
+            ),
+        ],
+        responses=CommandHistorySerializer(many=True),
+    ),
+    retrieve=extend_schema(
+        description='Get a specific command record by ID.',
+        responses=CommandHistorySerializer,
+    ),
+    create=extend_schema(
+        description=(
+            'Create a new command record.'
+            'Status will be set to \'pending\' by default.'
+        ),
+        responses=CommandHistorySerializer,
+    ),
+    partial_update=extend_schema(
+        description='Update command status or result (partial).',
+        responses=CommandHistorySerializer,
+    ),
+    destroy=extend_schema(
+        description='Delete command record by ID.',
+    ),
+)
 class CommandHistoryViewSet(viewsets.ModelViewSet):
     queryset = CommandHistory.objects.all()
     serializer_class = CommandHistorySerializer
@@ -95,8 +146,30 @@ class CommandHistoryViewSet(viewsets.ModelViewSet):
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
 
+@extend_schema(
+    description='Agent fetches a pending command by providing its hostname.',
+    parameters=[
+        OpenApiParameter(
+            name='hostname',
+            type=OpenApiTypes.STR,
+            location=OpenApiParameter.QUERY,
+            required=True,
+            description='Unique hostname of the agent.'
+        )
+    ],
+    responses={
+        200: CommandHistorySerializer,
+        204: OpenApiResponse(description='No pending commands'),
+        400: OpenApiResponse(description='Hostname is required')
+    }
+)
 @api_view(['GET'])
 def fetch_pending_command(request):
+    """
+    Endpoint for agents to request pending commands.
+    Returns the earliest command with status 'pending'
+    for the given hostname.
+    """
     hostname = request.query_params.get('hostname')
 
     if not hostname:
@@ -118,6 +191,19 @@ def fetch_pending_command(request):
     return Response(serializer.data)
 
 
+@extend_schema(
+        request=CommandHistorySerializer,
+        responses={
+            200: CommandHistorySerializer,
+            400: OpenApiResponse(
+                description='Validation error or invalid status'
+            ),
+            404: OpenApiResponse(description='Command not found or ID missing')
+        },
+        description=(
+            'Agent submits the result or status update for a command by ID.'
+        ),
+)
 @api_view(['PATCH'])
 def submit_command_result(request):
     command_id = request.data.get('id')
@@ -155,6 +241,10 @@ def submit_command_result(request):
 
 
 def dashboard_view(request):
+    """
+    Render the monitoring dashboard page.
+    Standard Django HTML view, not part of API.
+    """
     agents = get_latest_agents()
 
     return render(

--- a/pydata_center/monitoring/views.py
+++ b/pydata_center/monitoring/views.py
@@ -81,13 +81,9 @@ def receive_status(request):
         ),
         parameters=[
             OpenApiParameter(
-                name='hostname',
+                name='status',
                 type=str, location=OpenApiParameter.QUERY,
-                description='Filter by agent hostname'
-            ),
-            OpenApiParameter(
-                name='status', type=str,
-                location=OpenApiParameter.QUERY,
+                enum=[choice[0] for choice in CommandHistory.STATUS_CHOICES],
                 description='Filter by command status'
             ),
         ],

--- a/pydata_center/pydata_center/health.py
+++ b/pydata_center/pydata_center/health.py
@@ -13,11 +13,15 @@ logger = logging.getLogger(__name__)
 
 @extend_schema(
         responses={
-            200: OpenApiResponse(
+            status.HTTP_200_OK: OpenApiResponse(
                 description='Database and application are available.'
             ),
-            503: OpenApiResponse(description='Database connection failed.'),
-            500: OpenApiResponse(description='Unexpected health check error.')
+            status.HTTP_503_SERVICE_UNAVAILABLE: OpenApiResponse(
+                description='Database connection failed.'
+            ),
+            status.HTTP_500_INTERNAL_SERVER_ERROR: OpenApiResponse(
+                description='Unexpected health check error.'
+            ),
         },
         description=(
             'Health check endpoint that verifies'

--- a/pydata_center/pydata_center/health.py
+++ b/pydata_center/pydata_center/health.py
@@ -3,6 +3,7 @@ import logging
 from django.db import connections
 from django.db.utils import OperationalError
 from django.utils.timezone import now
+from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import status
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
@@ -10,6 +11,19 @@ from rest_framework.response import Response
 logger = logging.getLogger(__name__)
 
 
+@extend_schema(
+        responses={
+            200: OpenApiResponse(
+                description='Database and application are available.'
+            ),
+            503: OpenApiResponse(description='Database connection failed.'),
+            500: OpenApiResponse(description='Unexpected health check error.')
+        },
+        description=(
+            'Health check endpoint that verifies'
+            'application and database availability.'
+        ),
+)
 @api_view(['GET'])
 def health_check(request):
     """

--- a/pydata_center/pydata_center/health.py
+++ b/pydata_center/pydata_center/health.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 @extend_schema(
+        tags=['Health'],
         responses={
             status.HTTP_200_OK: OpenApiResponse(
                 description='Database and application are available.'
@@ -24,7 +25,7 @@ logger = logging.getLogger(__name__)
             ),
         },
         description=(
-            'Health check endpoint that verifies'
+            'Health check endpoint that verifies '
             'application and database availability.'
         ),
 )


### PR DESCRIPTION
Implemented comprehensive API documentation across all views and endpoints using `drf-spectacular`. Both Swagger UI and ReDoc are enabled. 

•	Swagger UI at /api/v1/schema/swagger-ui/
•	ReDoc UI at /api/v1/schema/redoc/

Also, added docstrings for clarity in non-API views (e.g., `dashboard_view`)