### PR TITLE
 Hotfix dashboard: Correct table colspan in empty view

### DIFF
--- a/pydata_center/monitoring/templates/monitoring/dashboard.html
+++ b/pydata_center/monitoring/templates/monitoring/dashboard.html
@@ -45,7 +45,7 @@
         </tr>
       {% empty %}
         <tr>
-          <td colspan="5">No agent data available.</td>
+          <td colspan="6">No agent data available.</td>
         </tr>
       {% endfor %}
     </tbody>


### PR DESCRIPTION
The dashboard table has 6 columns after adding the "Healthy" column, but the {% empty %} block still has colspan="5". This PR updates it to colspan="6" to preserve correct layout and avoid broken alignment when there are no agents to display.