### PR TITLE
133 hotfix make dataclass message objects in monitoring json serializable

### DIFF
--- a/pydata_center/monitoring/discord.py
+++ b/pydata_center/monitoring/discord.py
@@ -26,7 +26,7 @@ def send_async_discord_message(message: DiscordMessage):
     """
     try:
         response = requests.post(
-            message.webhook, json={'content': message.content}
+            message['webhook'], json={'content': message['content']}
         )
         response.raise_for_status()
 
@@ -51,8 +51,8 @@ def send_async_discord_message(message: DiscordMessage):
         # Identify possibly problematic webhook.
         logger.error(
             f'Webhook hash: '
-            f'{hashlib.sha256(message.webhook.encode()).hexdigest()[:8]}'
+            f'{hashlib.sha256(message["webhook"].encode()).hexdigest()[:8]}'
         )
 
-        if not message.fail_silently:
+        if not message['fail_silently']:
             raise type(e)('Sending Discord message failed.')

--- a/pydata_center/monitoring/discord.py
+++ b/pydata_center/monitoring/discord.py
@@ -17,16 +17,18 @@ class DiscordMessage:
 
 
 @shared_task
-def send_async_discord_message(message: DiscordMessage):
+def send_async_discord_message(serialized_message):
     """
     Send Discord message asynchronously using provided webhook.
 
     Parameters:
-        message (DiscordMessage): DiscordMessage dataclass instance.
+        message (Any): JSON-serialized DiscordMessage.
     """
     try:
+        message = DiscordMessage(**serialized_message)
+
         response = requests.post(
-            message['webhook'], json={'content': message['content']}
+            message.webhook, json={'content': message.content}
         )
         response.raise_for_status()
 
@@ -40,6 +42,8 @@ def send_async_discord_message(message: DiscordMessage):
                 f'POST request sent succesfully. Discord reposnse: '
                 f'{response.status_code} {response.text}'
             )
+    except TypeError as e:
+        logger.error(f'Error due to missing or invalid arguments: {e}')
     except (
         requests.exceptions.ConnectionError,
         requests.exceptions.InvalidURL,
@@ -51,8 +55,8 @@ def send_async_discord_message(message: DiscordMessage):
         # Identify possibly problematic webhook.
         logger.error(
             f'Webhook hash: '
-            f'{hashlib.sha256(message["webhook"].encode()).hexdigest()[:8]}'
+            f'{hashlib.sha256(message.webhook.encode()).hexdigest()[:8]}'
         )
 
-        if not message['fail_silently']:
+        if not message.fail_silently:
             raise type(e)('Sending Discord message failed.')

--- a/pydata_center/monitoring/discord.py
+++ b/pydata_center/monitoring/discord.py
@@ -17,15 +17,17 @@ class DiscordMessage:
 
 
 @shared_task
-def send_async_discord_message(serialized_message):
+def send_async_discord_message(message):
     """
     Send Discord message asynchronously using provided webhook.
 
     Parameters:
-        message (Any): JSON-serialized DiscordMessage.
+        message (Any): Instance of DiscordMessage (if function is called
+            explicitly) or JSON-serialized DiscordMessage.
     """
     try:
-        message = DiscordMessage(**serialized_message)
+        if not isinstance(message, DiscordMessage):
+            message = DiscordMessage(**message)
 
         response = requests.post(
             message.webhook, json={'content': message.content}

--- a/pydata_center/monitoring/email.py
+++ b/pydata_center/monitoring/email.py
@@ -23,9 +23,9 @@ def send_async_email(message: EmailMessage):
         message (EmailMessage): EmailMessage dataclass instance.
     """
     send_mail(
-        subject=message.subject,
-        message=message.body,
-        recipient_list=message.recipients,
-        from_email=message.sender,
-        fail_silently=message.fail_silently,
+        subject=message['subject'],
+        message=message['body'],
+        recipient_list=message['recipients'],
+        from_email=message['sender'],
+        fail_silently=message['fail_silently'],
     )

--- a/pydata_center/monitoring/email.py
+++ b/pydata_center/monitoring/email.py
@@ -18,15 +18,17 @@ class EmailMessage:
 
 
 @shared_task
-def send_async_email(serialized_message):
+def send_async_email(message):
     """
     Wraps Django's send_mail to send emails asynchronously.
 
     Parameters:
-        serialized_message (Any): JSON-serialized EmailMessage.
+        message (Any): Instance of EmailMessage (if function is called
+            explicitly) or JSON-serialized EmailMessage.
     """
     try:
-        message = EmailMessage(**serialized_message)
+        if not isinstance(message, EmailMessage):
+            message = EmailMessage(**message)
 
         send_mail(
             subject=message.subject,

--- a/pydata_center/monitoring/email.py
+++ b/pydata_center/monitoring/email.py
@@ -1,8 +1,11 @@
+import logging
 from dataclasses import dataclass
 from typing import Union
 
 from celery import shared_task
 from django.core.mail import send_mail
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -15,17 +18,22 @@ class EmailMessage:
 
 
 @shared_task
-def send_async_email(message: EmailMessage):
+def send_async_email(serialized_message):
     """
     Wraps Django's send_mail to send emails asynchronously.
 
     Parameters:
-        message (EmailMessage): EmailMessage dataclass instance.
+        serialized_message (Any): JSON-serialized EmailMessage.
     """
-    send_mail(
-        subject=message['subject'],
-        message=message['body'],
-        recipient_list=message['recipients'],
-        from_email=message['sender'],
-        fail_silently=message['fail_silently'],
-    )
+    try:
+        message = EmailMessage(**serialized_message)
+
+        send_mail(
+            subject=message.subject,
+            message=message.body,
+            recipient_list=message.recipients,
+            from_email=message.sender,
+            fail_silently=message.fail_silently,
+        )
+    except TypeError as e:
+        logger.error(f'Error due to missing or invalid arguments: {e}')

--- a/pydata_center/monitoring/tests/test_api.py
+++ b/pydata_center/monitoring/tests/test_api.py
@@ -8,6 +8,7 @@ from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
 from monitoring.discord import DiscordMessage, send_async_discord_message
+from monitoring.email import send_async_email
 from monitoring.models import AgentMetric, AlertRule, ServerStatus
 from monitoring.tasks import evaluate_agent_alerts
 from rest_framework import status
@@ -410,6 +411,35 @@ class ReceiveStatusEndpointTests(APITestCase):
             response.data,
             "'server_name' should be reported as missing"
         )
+
+
+@pytest.mark.parametrize('func,msg', [
+    (send_async_discord_message, {'content': 'mock-content'}),
+    (
+        send_async_discord_message,
+        {'content': 'mock-content', 'webhook': 'mock-webhook', 'bad': 'arg'}
+    ),
+    (send_async_email, {'body': 'mock-body'}),
+    (
+        send_async_email,
+        {
+            'subject': 'mock-subject',
+            'body': 'mock-body',
+            'recipients': ['mock-rec'],
+            'bad': 'arg',
+        }
+    ),
+])
+def test_send_async_bad_serialized_message(caplog, func, msg):
+    """
+    Test handling and logging of invalid serialized message passed to
+    send_async_discord_message or send_async_email.
+    """
+    with caplog.at_level('ERROR'):
+        result = func(msg)
+
+    assert result is None
+    assert 'Error due to missing or invalid arguments' in caplog.text
 
 
 @pytest.mark.parametrize('status_code', [200, 204])

--- a/pydata_center/pydata_center/settings.py
+++ b/pydata_center/pydata_center/settings.py
@@ -10,12 +10,15 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/4.2/ref/settings/
 """
 
+import json
 import os
 import sys
+from dataclasses import asdict, is_dataclass
 from datetime import timedelta
 from pathlib import Path
 
 from dotenv import load_dotenv
+from kombu.serialization import register
 
 # Load environment variables from .env file
 load_dotenv()
@@ -278,6 +281,26 @@ SIMPLE_JWT = {
 }
 
 ALERT_RATE_LIMIT_SECONDS = 300
+
+
+class CeleryDataclassJSONEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if is_dataclass(obj):
+            return asdict(obj)
+        return super().default(obj)
+
+
+register(
+    'celery_dataclass_json',
+    lambda o: json.dumps(o, cls=CeleryDataclassJSONEncoder).encode(),
+    lambda s: json.loads(s),
+    content_type='application/x-dataclass-json',
+    content_encoding='utf-8'
+)
+
+CELERY_TASK_SERIALIZER = 'celery_dataclass_json'
+CELERY_RESULT_SERIALIZER = 'celery_dataclass_json'
+CELERY_ACCEPT_CONTENT = ['celery_dataclass_json']
 
 CELERY_BEAT_SCHEDULE = {
     'evaluate-agent-alerts-every-5-minutes': {

--- a/pydata_center/pydata_center/settings.py
+++ b/pydata_center/pydata_center/settings.py
@@ -13,12 +13,13 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 import json
 import os
 import sys
-from dataclasses import asdict, is_dataclass
 from datetime import timedelta
 from pathlib import Path
 
 from dotenv import load_dotenv
 from kombu.serialization import register
+
+from pydata_center.utils import DataclassJSONEncoder
 
 # Load environment variables from .env file
 load_dotenv()
@@ -282,28 +283,20 @@ SIMPLE_JWT = {
 
 ALERT_RATE_LIMIT_SECONDS = 300
 
-
-class CeleryDataclassJSONEncoder(json.JSONEncoder):
-    def default(self, obj):
-        if is_dataclass(obj):
-            return asdict(obj)
-        return super().default(obj)
-
-
 register(
-    'celery_dataclass_json',
-    lambda o: json.dumps(o, cls=CeleryDataclassJSONEncoder).encode(),
+    'dataclass_json',
+    lambda o: json.dumps(o, cls=DataclassJSONEncoder).encode(),
     lambda s: json.loads(s),
     content_type='application/x-dataclass-json',
     content_encoding='utf-8'
 )
 
-CELERY_TASK_SERIALIZER = 'celery_dataclass_json'
-CELERY_RESULT_SERIALIZER = 'celery_dataclass_json'
-CELERY_ACCEPT_CONTENT = ['celery_dataclass_json']
+CELERY_TASK_SERIALIZER = 'dataclass_json'
+CELERY_RESULT_SERIALIZER = 'dataclass_json'
+CELERY_ACCEPT_CONTENT = ['dataclass_json']
 
 CELERY_BEAT_SCHEDULE = {
-    'evaluate-agent-alerts-every-5-minutes': {
+    'evaluate-agent-alerts-every-30-seconds': {
         'task': 'monitoring.tasks.evaluate_agent_alerts',
         'schedule': 30.0,
     },

--- a/pydata_center/pydata_center/utils/__init__.py
+++ b/pydata_center/pydata_center/utils/__init__.py
@@ -1,0 +1,1 @@
+from .encoders import DataclassJSONEncoder

--- a/pydata_center/pydata_center/utils/encoders.py
+++ b/pydata_center/pydata_center/utils/encoders.py
@@ -1,0 +1,10 @@
+import json
+from dataclasses import asdict, is_dataclass
+
+
+class DataclassJSONEncoder(json.JSONEncoder):
+    """Ensures Python dataclasses are JSON serializable."""
+    def default(self, obj):
+        if is_dataclass(obj):
+            return asdict(obj)
+        return super().default(obj)


### PR DESCRIPTION
This PR fixes the bug of Celery tasks in `monitoring` receiving non-serializable objects as arguments. The steps are the following:

- In `settings.py`, Celery is fed a custom JSON encoder for dataclasses, so that in `AlertDispatcher` we can pass message objects without any extra care.
- In Celery tasks (`send_async_discord_message` and `send_async_email`), if message object has been serialized, the reconstruction of the original dataclass will be attempted, i.e.,

```python
if not isinstance(message, DiscordMessage):
    message = DiscordMessage(**message)
```

This step also serves as additional argument validation.
- Added unit tests for the case when serialized input is invalid.