### PR TITLE
Hotfix(tests): Stabilize tests in test_views_alerts.py for isolated runs

### DIFF
--- a/pydata_center/monitoring/tests/test_views_alerts.py
+++ b/pydata_center/monitoring/tests/test_views_alerts.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from unittest.mock import patch
 
 import pytest
-from django.contrib.auth.models import Group, User
+from django.contrib.auth.models import Group, Permission, User
 from django.urls import reverse
 from monitoring.models import CommandHistory
 from rest_framework.test import APIClient
@@ -26,6 +26,8 @@ def authenticated_client(db):
     user = User.objects.create_user(username='test_user')
     # add user to Operator group
     operator_group, _ = Group.objects.get_or_create(name='Operator')
+    permission = Permission.objects.get(codename='add_serverstatus')
+    operator_group.permissions.add(permission)
     user.groups.add(operator_group)
     client = APIClient()
     client.force_authenticate(user=user)


### PR DESCRIPTION
### Description:

Related to: #173 

This PR resolves flaky test failures in test_views_alerts.py by making its test fixture self-contained. This is part of a larger effort to stabilize the test suite after the RBAC implementation.

### The Problem

As described in the related issue, tests in test_views_alerts.py were failing with a 403 Forbidden error when run in isolation. This was because the authenticated_client fixture did not grant the necessary 'monitoring.add_serverstatus' permission required by the receive_status view.

### The Solution

The authenticated_client fixture within monitoring/tests/test_views_alerts.py has been updated to explicitly grant the 'monitoring.add_serverstatus' permission to the test user's group. This ensures the test is self-sufficient and passes regardless of execution order.

### Note: 

A similar fix for test_views_dashboard.py was implemented separately in PR #170 