### PR TITLE
fix: enhance installation scripts for Nginx and FastAPI with conditional checks

### DIFF
--- a/agents_infra/vagrant/provision/install_nginx.sh
+++ b/agents_infra/vagrant/provision/install_nginx.sh
@@ -1,12 +1,19 @@
 #!/bin/bash
 set -e
 
-# Install Nginx
-sudo apt-get update
-sudo apt-get install -y nginx
+# Install Nginx if not already installed
+if ! dpkg -l | grep -q nginx; then
+    sudo apt-get update
+    sudo apt-get install -y nginx
+else
+    echo "[INFO] Nginx already installed."
+fi
 
-# Configure Nginx as reverse proxy
-cat << EOF | sudo tee /etc/nginx/sites-available/fastapi
+# Configure Nginx as reverse proxy only if config differs
+NGINX_CONF="/etc/nginx/sites-available/fastapi"
+NEW_CONF="/tmp/fastapi_nginx_conf.tmp"
+
+cat << EOF > "$NEW_CONF"
 server {
     listen 80;
     server_name _;
@@ -27,8 +34,14 @@ server {
 }
 EOF
 
-# Enable the site and restart Nginx
-sudo ln -sf /etc/nginx/sites-available/fastapi /etc/nginx/sites-enabled/
-sudo rm -f /etc/nginx/sites-enabled/default
-sudo nginx -t
-sudo systemctl reload nginx
+if ! cmp -s "$NEW_CONF" "$NGINX_CONF"; then
+    sudo cp "$NEW_CONF" "$NGINX_CONF"
+    sudo ln -sf "$NGINX_CONF" /etc/nginx/sites-enabled/
+    sudo rm -f /etc/nginx/sites-enabled/default
+    sudo nginx -t
+    sudo systemctl reload nginx
+    echo "[INFO] Nginx config updated and reloaded."
+else
+    echo "[INFO] Nginx config unchanged."
+fi
+rm -f "$NEW_CONF"

--- a/agents_infra/vagrant/provision/setup_fastapi.sh
+++ b/agents_infra/vagrant/provision/setup_fastapi.sh
@@ -1,22 +1,31 @@
 #!/bin/bash
 set -e
 
-# Install python3-venv
-sudo apt-get update
-sudo apt-get install -y python3-venv
+# Install python3-venv if not already installed
+if ! dpkg -l | grep -q python3-venv; then
+    sudo apt-get update
+    sudo apt-get install -y python3-venv
+else
+    echo "[INFO] python3-venv already installed."
+fi
 
-# Create virtual environment in /opt
-sudo mkdir -p /opt/fastapi
-sudo chown vagrant:vagrant /opt/fastapi
-cd /opt/fastapi
-python3 -m venv venv
-source venv/bin/activate
+# Create virtual environment in /opt if not present
+if [ ! -d /opt/fastapi/venv ]; then
+    sudo mkdir -p /opt/fastapi
+    sudo chown vagrant:vagrant /opt/fastapi
+    cd /opt/fastapi
+    python3 -m venv venv
+    source venv/bin/activate
+    pip install -r /home/vagrant/server/requirements.txt
+else
+    echo "[INFO] Python venv already exists."
+fi
 
-# Install requirements
-pip install -r /home/vagrant/server/requirements.txt
+# Create systemd service for FastAPI only if changed
+SERVICE_FILE="/etc/systemd/system/fastapi.service"
+NEW_SERVICE="/tmp/fastapi_service.tmp"
 
-# Create systemd service for FastAPI
-sudo tee /etc/systemd/system/fastapi.service << EOF
+cat << EOF > "$NEW_SERVICE"
 [Unit]
 Description=FastAPI via Gunicorn
 After=network.target
@@ -40,7 +49,20 @@ StandardError=journal
 WantedBy=multi-user.target
 EOF
 
-# Enable and start the service
-sudo systemctl daemon-reload
-sudo systemctl enable fastapi
-sudo systemctl start fastapi
+RELOAD_SERVICE=0
+if [ ! -f "$SERVICE_FILE" ] || ! cmp -s "$NEW_SERVICE" "$SERVICE_FILE"; then
+    sudo cp "$NEW_SERVICE" "$SERVICE_FILE"
+    RELOAD_SERVICE=1
+    echo "[INFO] fastapi.service updated."
+else
+    echo "[INFO] fastapi.service unchanged."
+fi
+rm -f "$NEW_SERVICE"
+
+if [ $RELOAD_SERVICE -eq 1 ]; then
+    sudo systemctl daemon-reload
+    sudo systemctl enable fastapi
+    sudo systemctl restart fastapi
+else
+    echo "[INFO] fastapi.service not restarted."
+fi


### PR DESCRIPTION
Updated provision scripts, related to web server. Now scrips:
- check if nginx is already installed, and skips installation in that case;
- checks if nginx config was changed, if it wasn't - skip systemctl service creation;
- similarly, checks for dependencies for fastapi and fastapi's systemctl service changes.