### PR TITLE
HOTFIX: Monitoring tests

### DIFF
--- a/pydata_center/monitoring/tests/benchmark/test_api_benchmarks.py
+++ b/pydata_center/monitoring/tests/benchmark/test_api_benchmarks.py
@@ -4,7 +4,7 @@ import random
 import pytest
 import requests
 
-BASE_URL = os.getenv('LOCUST_TARGET', 'http://localhost:8000')
+BASE_URL = os.getenv('LOCUST_TARGET', 'http://0.0.0.0:8000')
 USERNAME = os.getenv('LOCUST_USERNAME', 'locust_tester')
 PASSWORD = os.getenv('LOCUST_PASSWORD', 'supersecret')
 

--- a/pydata_center/monitoring/tests/benchmark/test_api_benchmarks.py
+++ b/pydata_center/monitoring/tests/benchmark/test_api_benchmarks.py
@@ -4,7 +4,7 @@ import random
 import pytest
 import requests
 
-BASE_URL = os.getenv('LOCUST_TARGET', 'http://0.0.0.0:8000')
+BASE_URL = os.getenv('LOCUST_TARGET', 'http://localhost:8000')
 USERNAME = os.getenv('LOCUST_USERNAME', 'locust_tester')
 PASSWORD = os.getenv('LOCUST_PASSWORD', 'supersecret')
 

--- a/pydata_center/pytest.ini
+++ b/pydata_center/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = pydata_center.settings
 python_files = tests.py test_*.py *_tests.py
-celery = true
+addopts = --ignore=pydata_center/monitoring/tests/benchmark/test_api_benchmarks.py


### PR DESCRIPTION
**This Pull Request introduces fix to monitoring tests.**
Main Changes:
File structure: Moved pydata_center/__init__.py to pydata_center/monitoring/tests/__init__.py.
Pytest configuration:
Removed unnecessary celery = true configuration.
Added an option to ignore test_api_benchmarks.py in the addopts setting.