### PR TITLE
207 refactor dashboard logic to use is active flag instead of subquery

### DIFF
--- a/pydata_center/monitoring/helpers.py
+++ b/pydata_center/monitoring/helpers.py
@@ -32,12 +32,8 @@ def get_latest_agents(query_params=None, cutoff_seconds=60):
                     else 'timestamp__lt'
                 ] = cutoff_time
 
-    latest_subquery = ServerStatus.objects.filter(
-        hostname=OuterRef('hostname')
-    ).order_by('-timestamp').values('pk')[:1]
-
     latest_statuses = ServerStatus.objects.filter(
-        pk=Subquery(latest_subquery),
+        is_active=True,
         **filters
     ).order_by('hostname')
 

--- a/pydata_center/monitoring/tests/test_helpers.py
+++ b/pydata_center/monitoring/tests/test_helpers.py
@@ -77,6 +77,48 @@ class TestGetLatestAgents:
                 ==
                 newest_vm02.timestamp)
 
+    def test_ignores_inactive_record_even_if_newer(self):
+        """
+        Test that the function selects the active record, even if an
+        inactive record for the same host has a more recent timestamp.
+        """
+        ServerStatus.objects.all().delete()
+        hostname = 'edge-case-vm'
+
+        active_and_older = ServerStatus.objects.create(
+            hostname=hostname,
+            ip='192.168.10.1',
+            uptime=1000,
+            timestamp=self.right_now - timedelta(hours=1),
+            healthy=True,
+            is_active=True
+        )
+        ServerStatus.objects.create(
+            hostname=hostname,
+            ip='192.168.10.2',
+            uptime=2000,
+            timestamp=self.right_now,
+            healthy=False,
+            is_active=False
+        )
+
+        agents = get_latest_agents()
+
+        assert len(agents) == 1, \
+            'Should only return one record for the host.'
+
+        expected_agent = {
+            'hostname': active_and_older.hostname,
+            'ip': active_and_older.ip,
+            'uptime': active_and_older.uptime,
+            'timestamp': active_and_older.timestamp,
+            'healthy': active_and_older.healthy,
+            'tags': active_and_older.tags,
+            'offline': True
+        }
+        assert agents[0] == expected_agent, \
+            'The returned agent must be the one marked as is_active=True.'
+
     def test_correctly_identifies_offline_agent(self):
         """
         Tests that an agent that has not reported recently is


### PR DESCRIPTION
### Description

Closes #207 

This PR builds upon the improvements made in #190 , where we introduced the `is_active=True` flag and a database-level `UniqueConstraint` to guarantee that only one active `ServerStatus` record exists per hostname.

Now that this logic is in place, we can simplify and optimize the logic powering the agent dashboard.

---

### Problem

The helper function `get_latest_agents()` used a costly Subquery to retrieve the latest status per hostname. While this made sense earlier, it is now redundant - the `is_active=True` flag directly represents the "latest" record for any given agent.

---

### Solution

Refactored the `get_latest_agents()` helper by:

- Removing the `Subquery` logic.
- Replacing it with a simple `.filter(is_active=True)` lookup.
- Retaining all existing dashboard filters (e.g., hostname, ip, tags, healthy, status).
- Preserving logic that marks agents as `offline` based on timestamp cutoff.

---

### Tests

- All existing tests in `test_helpers.py` pass without modification.
- New test added: `test_ignores_inactive_record_even_if_newer` - confirms that the function does not return newer records if they are marked inactive - ensuring correctness of `is_active` logic.

---

### Acceptance Criteria

- [x] The `get_latest_agents` function is refactored to use `.filter(is_active=True).`
- [x] The complex `Subquery` logic is completely removed.
- [x] All existing `dashboard filters (hostname, ip, tags, healthy, status)` continue to work correctly with the new logic.
- [x] The function correctly determines `the offline status` for agents based on their `timestamp`.
- [x] Unit tests in `test_helpers.py` are extended to cover the refactored logic.

---

Ready for review!