### PR TITLE
209 fix flaky agent ping test by stabilizing timestamp based ordering

### DIFF
--- a/pydata_center/monitoring/tasks.py
+++ b/pydata_center/monitoring/tasks.py
@@ -187,7 +187,7 @@ def save_agent_ping_status(agent_ip, status_data):
     last_status = (
         AgentPingStatus.objects
         .filter(ip=agent_ip)
-        .order_by('-timestamp')
+        .order_by('-timestamp', '-id')
         .first()
     )
     new_status = status_data.get('status', 'unreachable')

--- a/pydata_center/monitoring/tests/test_api.py
+++ b/pydata_center/monitoring/tests/test_api.py
@@ -1680,12 +1680,17 @@ class TestSaveAgentPingStatus:
         }
 
         save_agent_ping_status(ip, data)
-        status = (
+
+        assert AgentPingStatus.objects.filter(ip=ip).count() == 2, \
+            'A new ping status record should have been created.'
+
+        latest_status = (
             AgentPingStatus.objects
-            .filter(ip=ip).order_by('-timestamp').first()
+            .filter(ip=ip).order_by('-timestamp', '-id').first()
         )
 
-        assert status.uptime == 150, 'uptime was not updated to 150'
+        assert latest_status.uptime == 150, \
+            'The latest record should have the new uptime.'
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
### Description

Closes: #209

---

### Problem 

The test `test_uptime_always_updated` was intermittently failing. The underlying reason is that the function `save_agent_ping_status()` always creates a new record, but the test was relying on `order_by('-timestamp').first()` to retrieve the latest one.

However, if two records share the same timestamp (which is possible due to rapid creation), the query result becomes nondeterministic - sometimes returning the old record instead of the new one. 

---

###  Solution

The issue was resolved on two fronts:

1. Test fix
- The test now uses `.order_by('-timestamp', '-id')` to reliably retrieve the newest record.
- Added an additional assertion to confirm that two records were created `(assert count == 2)` to match the expected behavior of the function.

2. Function fix
- The `save_agent_ping_status()` function was updated to use `.order_by('-timestamp', '-id')` when retrieving `last_status`, ensuring consistency in production code and logging logic.

---

Ready for review!