### PR TITLE
Refactor permission classes to use inheritance

### DIFF
--- a/pydata_center/monitoring/permissions.py
+++ b/pydata_center/monitoring/permissions.py
@@ -1,17 +1,32 @@
+from typing import ClassVar, Iterable
+
 from rest_framework.permissions import SAFE_METHODS, BasePermission
 
 
-class IsAdminOrOperatorForWrite(BasePermission):
+class ReadOnlyOrGroupWritePermission(BasePermission):
     """
-    - Allow read-only (GET, HEAD, OPTIONS) to everyone.
-    - Allow write (POST, PATCH, DELETE) only to Admin and Operator.
+    Allow read-only access (GET, HEAD, OPTIONS) to everyone.
+    Allow write access only to users in `allowed_groups`.
     """
+    allowed_groups: ClassVar[Iterable[str]] = ()
 
-    def has_permission(self, request, view):
+    def has_permission(self, request, view) -> bool:
+        # 1) If this is a safe method, grant access immediately
         if request.method in SAFE_METHODS:
-            return True  # Viewer, Admin, Operator - GET access
+            return True
 
-        if not request.user or not request.user.is_authenticated:
+        # 2) Ensure the user is authenticated
+        user = getattr(request, 'user', None)
+        if not getattr(user, 'is_authenticated', False):
             return False
-        return request.user.groups.filter(
-            name__in=['Admin', 'Operator']).exists()
+
+        # 3) Check that the user belongs to one of the allowed groups
+        return user.groups.filter(name__in=self.allowed_groups).exists()
+
+
+class IsAdminOrOperatorForWrite(ReadOnlyOrGroupWritePermission):
+    """
+    Read-only for everyone.
+    Write only for users in the 'Admin' or 'Operator' groups.
+    """
+    allowed_groups = ('Admin', 'Operator')


### PR DESCRIPTION
Currently, our `IsAdminOrOperatorForWrite` permission class mixes both
read-only and group-based write logic directly in one class. This makes
it harder to extend when we need similar permissions for other roles.

What was implemented:

-  I introduced `ReadOnlyOrGroupWritePermission` as a generic base class. 
- Updated `IsAdminOrOperatorForWrite` to subclass the new base and set `allowed_groups = ('Admin', 'Operator')`.
- Removed duplicated logic from the subclass. 